### PR TITLE
docs(example): add missing `expectModuleToBeCalledWith` in example

### DIFF
--- a/docs/content/en/examples/module.md
+++ b/docs/content/en/examples/module.md
@@ -7,7 +7,7 @@ categoryPosition: 3
 ---
 
 ```js
-import { setupTest, getNuxt } from '@nuxt/test-utils'
+import { setupTest, expectModuleToBeCalledWith, getNuxt } from '@nuxt/test-utils'
 
 describe('module', () => {
   setupTest({


### PR DESCRIPTION
Into the nuxt module example, it miss the import of `expectModuleToBeCalledWith` 