### PR TITLE
feat(nuxt): allow function and promise config

### DIFF
--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -9,13 +9,38 @@ export async function loadNuxt () {
   ctx.nuxt = new Nuxt(ctx.options.config)
 }
 
+function loadConfig () {
+  const { options } = getContext()
+  return (
+    import(resolve(options.rootDir, options.configFile))
+      // .then(m => /* istanbul ignore next */ m.default || m)
+      .then(async (m) => {
+        if (m.default) {
+          m = m.default
+        }
+
+        if (typeof m === 'function') {
+          try {
+            m = await m()
+            if (m.default) {
+              m = m.default
+            }
+          } catch (error) {
+            console.error(error)
+            throw new Error('Error while fetching async configuration')
+          }
+        }
+
+        return m
+      })
+  )
+}
+
 export async function loadFixture () {
   const { options } = getContext()
 
   options.rootDir = resolve(options.testDir, options.fixture)
-
-  const loadedConfig = await import(resolve(options.rootDir, options.configFile))
-    .then(m => /* istanbul ignore next */ m.default || m)
+  const loadedConfig = await loadConfig()
 
   options.config = defu(options.config, loadedConfig)
 
@@ -24,14 +49,17 @@ export async function loadFixture () {
   }
 
   if (!options.config.buildDir) {
-    const randomId = Math.random().toString(36).substr(2, 8)
+    const randomId = Math.random()
+      .toString(36)
+      .substr(2, 8)
     options.config.buildDir = resolve(options.rootDir, '.nuxt', randomId)
   }
 }
 
 export async function loadNuxtPackage (name: string = 'nuxt') {
-  return await import(name + '-edge')
-    .catch(/* istanbul ignore next */ () => import(name))
+  return await import(name + '-edge').catch(
+    /* istanbul ignore next */ () => import(name)
+  )
 }
 
 export function getNuxt () {

--- a/test/fixtures/function/modules/module-a/error.vue
+++ b/test/fixtures/function/modules/module-a/error.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Error Layout
+  </div>
+</template>

--- a/test/fixtures/function/modules/module-a/index.js
+++ b/test/fixtures/function/modules/module-a/index.js
@@ -1,0 +1,18 @@
+const { resolve } = require('path')
+
+module.exports = function (options) {
+  this.addPlugin({
+    src: resolve(__dirname, 'plugin.js'),
+    fileName: 'plugin-a.js',
+    options
+  })
+
+  this.addLayout(resolve(__dirname, 'layout.vue'))
+  this.addLayout(resolve(__dirname, 'layout.vue'), 'name-layout')
+
+  this.addLayout(resolve(__dirname, 'error.vue'), 'error')
+
+  this.addServerMiddleware(resolve(__dirname, 'middleware.js'))
+
+  this.requireModule('~/modules/module-b')
+}

--- a/test/fixtures/function/modules/module-a/layout.vue
+++ b/test/fixtures/function/modules/module-a/layout.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <nuxt />
+  </div>
+</template>

--- a/test/fixtures/function/modules/module-a/middleware.js
+++ b/test/fixtures/function/modules/module-a/middleware.js
@@ -1,0 +1,3 @@
+module.exports = function (_req, _res, next) {
+  next()
+}

--- a/test/fixtures/function/modules/module-b/index.js
+++ b/test/fixtures/function/modules/module-b/index.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+
+}

--- a/test/fixtures/function/nuxt.config.async.error.js
+++ b/test/fixtures/function/nuxt.config.async.error.js
@@ -1,0 +1,1 @@
+module.exports = () => Promise.reject(new Error('Async Nuxt config error'))

--- a/test/fixtures/function/nuxt.config.async.js
+++ b/test/fixtures/function/nuxt.config.async.js
@@ -1,0 +1,3 @@
+const originalConfig = require('./nuxt.config')
+
+module.exports = () => Promise.resolve(originalConfig())

--- a/test/fixtures/function/nuxt.config.js
+++ b/test/fixtures/function/nuxt.config.js
@@ -1,0 +1,5 @@
+module.exports = () => ({
+  srcDir: __dirname,
+
+  modules: ['~/modules/module-a']
+})

--- a/test/fixtures/function/pages/index.vue
+++ b/test/fixtures/function/pages/index.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    Works!
+  </div>
+</template>
+
+<script>
+export default {
+}
+</script>

--- a/test/unit/nuxt.test.ts
+++ b/test/unit/nuxt.test.ts
@@ -1,0 +1,29 @@
+import { loadFixture } from '../../src'
+import { createContext } from '../../src/context'
+import basicFixtureConfig from '../fixtures/basic/nuxt.config'
+import functionFixtureConfig from '../fixtures/function/nuxt.config'
+
+describe('context', () => {
+  test('loads object fixture config', async () => {
+    const context = createContext({ fixture: './fixtures/basic' })
+    await loadFixture()
+    expect(context.options.config).toMatchObject(basicFixtureConfig)
+  })
+
+  test('loads function fixture config', async () => {
+    const context = createContext({ fixture: './fixtures/function' })
+    await loadFixture()
+    expect(context.options.config).toMatchObject(functionFixtureConfig())
+  })
+
+  test('loads async function fixture config', async () => {
+    const context = createContext({ fixture: './fixtures/function', configFile: 'nuxt.config.async.js' })
+    await loadFixture()
+    expect(context.options.config).toMatchObject(functionFixtureConfig())
+  })
+
+  test('throws error on async function fixture config with error', async () => {
+    createContext({ fixture: './fixtures/function', configFile: 'nuxt.config.async.error.js' })
+    await expect(loadFixture()).rejects.toThrow('Error while fetching async configuration')
+  })
+})

--- a/test/unit/nuxt.test.ts
+++ b/test/unit/nuxt.test.ts
@@ -3,7 +3,7 @@ import { createContext } from '../../src/context'
 import basicFixtureConfig from '../fixtures/basic/nuxt.config'
 import functionFixtureConfig from '../fixtures/function/nuxt.config'
 
-describe('context', () => {
+describe('nuxt', () => {
   test('loads object fixture config', async () => {
     const context = createContext({ fixture: './fixtures/basic' })
     await loadFixture()


### PR DESCRIPTION
Allow `loadFixture`to accept Nuxt configs declared as functions or promises.

Taken from https://github.com/nuxt/nuxt.js/blob/dev/packages/config/src/load.js#L61-L71