### PR TITLE
fix: detect `nuxt.config` with different extensions

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -57,7 +57,7 @@ export function createContext (options: Partial<NuxtTestOptions>): NuxtTestConte
   const _options: Partial<NuxtTestOptions> = defu(options, {
     testDir: resolve(process.cwd(), 'test'),
     fixture: 'fixture',
-    configFile: 'nuxt.config.js',
+    configFile: 'nuxt.config',
     setupTimeout: 60000,
     server: options.browser,
     build: options.browser || options.server,

--- a/test/unit/__snapshots__/context.test.ts.snap
+++ b/test/unit/__snapshots__/context.test.ts.snap
@@ -8,7 +8,7 @@ Object {
     },
     "build": undefined,
     "config": Object {},
-    "configFile": "nuxt.config.js",
+    "configFile": "nuxt.config",
     "fixture": "fixture",
     "server": undefined,
     "setupTimeout": 60000,


### PR DESCRIPTION
With `loadNuxtConfig` detect `nuxt.config.js` or `nuxt.config.ts` from https://github.com/nuxt/nuxt.js/blob/dev/packages/config/src/load.js#L11

Resolve #100 