### PR TITLE
refactor: Node’s native functionality used to get random port

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@babel/preset-typescript": "^7.13.0",
     "consola": "^2.15.3",
     "defu": "^3.2.2",
-    "get-port": "^5.1.1",
     "got": "^11.8.2"
   },
   "devDependencies": {

--- a/src/context.ts
+++ b/src/context.ts
@@ -36,7 +36,7 @@ export interface NuxtTestContext {
 
   nuxt?: {
     options: NuxtOptions
-    listen: (port?: number, host?: string, socket?: string) => any
+    listen: (port?: number | string, host?: string, socket?: string) => any
     ready: () => any
     close: (callback?: Function) => any
     resolver: any

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,17 +1,14 @@
-import getPort from 'get-port'
 import got, { OptionsOfUnknownResponseBody } from 'got'
 import { getContext } from './context'
 
 export async function listen () {
   const ctx = getContext()
   const { server } = ctx.options.config
-  const port = await getPort({
-    ...(server?.port && { port: Number(server?.port) })
-  })
 
-  ctx.url = 'http://localhost:' + port
+  const port = server?.port || 0
+  const { url } = await ctx.nuxt.listen(port)
 
-  await ctx.nuxt.listen(port)
+  ctx.url = url
 }
 
 export function get (path: string, options?: OptionsOfUnknownResponseBody) {
@@ -25,5 +22,7 @@ export function url (path: string) {
     throw new Error('server is not enabled')
   }
 
-  return ctx.url + path
+  const { href } = new URL(path, ctx.url)
+
+  return href
 }

--- a/test/e2e/server.test.ts
+++ b/test/e2e/server.test.ts
@@ -1,0 +1,128 @@
+import { resolve } from 'path'
+import { createServer } from 'http'
+import { setupTest, getContext, getNuxt } from '../../src'
+import { get } from '../../src/server'
+
+const baseConfig = {
+  testDir: resolve(__dirname, '..'),
+  fixture: 'fixtures/server'
+}
+
+describe('server', () => {
+  const port = 3000
+  const anotherServer = createServer()
+
+  beforeAll(() => {
+    anotherServer.listen({ host: 'localhost', port })
+  })
+  afterAll(() => {
+    anotherServer.close()
+  })
+
+  describe('by default', () => {
+    setupTest({
+      ...baseConfig,
+      server: true
+    })
+
+    test('listens on a random unused port', () => {
+      const { url } = getContext()
+      expect(url).toBeDefined()
+      expect(url).not.toContain(`localhost:${port}`)
+    })
+  })
+
+  describe('uses `config.server.port` value', () => {
+    setupTest({
+      ...baseConfig,
+      config: { server: { port } }
+    })
+
+    test('if port is already taken throws an error', async () => {
+      expect.assertions(1)
+      const nuxt = getNuxt()
+
+      try {
+        await nuxt.listen()
+      } catch (err) {
+        expect(err).toBeDefined()
+      }
+    })
+  })
+
+  describe.each([
+    [5050, 'an integer'],
+    ['5050', 'a string which can be converted to a number']
+  ])('uses `config.server.port` value', (port, msg) => {
+    setupTest({
+      ...baseConfig,
+      server: true,
+      config: { server: { port } }
+    })
+
+    test(`listens if the value is ${msg}`, () => {
+      const { url } = getContext()
+      expect(url).toContain('localhost:5050')
+    })
+  })
+
+  describe.each([
+    [-5050, 'negative number'],
+    [50.50, 'a float'],
+    ['fifty-fifty', 'a string which can not be converted to a number']
+  ])('uses `config.server.port` value', (port, msg) => {
+    setupTest({
+      ...baseConfig,
+      config: { server: { port } }
+    })
+
+    test(`throws if the value is ${msg}`, async () => {
+      expect.assertions(1)
+      const nuxt = getNuxt()
+
+      try {
+        await nuxt.listen()
+      } catch (err) {
+        expect(err).toBeDefined()
+      }
+    })
+  }
+  )
+})
+
+describe('`get()` helper', () => {
+  describe('returns a response', () => {
+    setupTest({
+      ...baseConfig,
+      server: true
+    })
+
+    test('for a path with leading slash', async () => {
+      const { body } = await get('/some-path')
+      expect(body).toContain('Some path')
+    })
+
+    test('for a path without leading slash', async () => {
+      const { body } = await get('some-path')
+      expect(body).toContain('Some path')
+    })
+
+    test('for a path with trailing slash', async () => {
+      const { body } = await get('some-path/')
+      expect(body).toContain('Some path')
+    })
+  })
+
+  describe('throws an error', () => {
+    setupTest(baseConfig)
+
+    test('if server is not enabled', async () => {
+      expect.assertions(1)
+      try {
+        await get('/')
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error)
+      }
+    })
+  })
+})

--- a/test/fixtures/server/nuxt.config.js
+++ b/test/fixtures/server/nuxt.config.js
@@ -1,0 +1,3 @@
+export default {
+  srcDir: __dirname
+}

--- a/test/fixtures/server/pages/some-path.vue
+++ b/test/fixtures/server/pages/some-path.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    Some path
+  </div>
+</template>
+
+<script>
+export default {
+}
+</script>

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -36,14 +36,3 @@ describe('setup with waitFor', () => {
     waitFor: 100
   })
 })
-
-describe('server', () => {
-  setupTest({
-    testDir: resolve(__dirname, '..'),
-    fixture: 'fixtures/basic'
-  })
-
-  test('should be error if server not enabled', () => {
-    expect(() => get('/')).toThrowError('server is not enabled')
-  })
-})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5494,11 +5494,6 @@ get-port-please@^1.0.0:
   dependencies:
     fs-memo "^1.2.0"
 
-get-port@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
-  integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
-
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"


### PR DESCRIPTION
*Typings.* `nuxt.listen()` handles numbers and strings as `port` property (see test). For example, a `string` might be useful if config is read using `process.env`.

*`URL` class.* I had to add it, because `nuxt.listen()` returns url with trailing slash included. That’s why `ctx.url + '/'` did not work. In general URL makes usage more flexible for the user (see test).

*`get-port`.* Was factoring out. I was looking at `get-port`’s code and could not fully understand how it works. Went to check Node’s docs on `server.listen()`:

> If port is omitted or is 0, the operating system will assign an arbitrary unused port...

It means that by calling `nuxt.listen(0)` we get random port with having a dependancy. Factoring out also effectively mitigates `get-port`’s [tiny chance of a race condition](https://github.com/sindresorhus/get-port#beware).

*Benchmark.* Checked speed, but I did not find any before / after difference.

*Tests.* I was trying to see if there is any need to validate the `port` value before passing it to `nuxt.listen()`. Only `number` and `string` are allowed in typings, so I was focusing only on these two (not arrays, objects, etc). Seems like `nuxt`, `connect` and `node` handle everything properly and throw errors. There is no need to validated the value. Tests were left in place as a proof. Good to have them for the future as well.