### PR TITLE
docs: update with windows-compatible example test

### DIFF
--- a/docs/content/en/api-reference/module-testing.md
+++ b/docs/content/en/api-reference/module-testing.md
@@ -26,7 +26,7 @@ Expect a specific method to be triggered while installing a module.
 ```js
 test('should inject plugin', () => {
   expectModuleToBeCalledWith('addPlugin', {
-    src: expect.stringContaining('templates/plugin.js'),
+    src: expect.stringMatching(/templates[\\/]plugin.js/),
     fileName: 'myPlugin.js',
     options: getNuxt().options.myModule
   })

--- a/docs/content/en/examples/module.md
+++ b/docs/content/en/examples/module.md
@@ -22,7 +22,7 @@ describe('module', () => {
 
   test('should inject plugin', () => {
     expectModuleToBeCalledWith('addPlugin', {
-      src: expect.stringContaining('templates/plugin.js'),
+      src: expect.stringMatching(/templates[\\/]plugin.js/),
       fileName: 'myPlugin.js',
       options: getNuxt().options.myModule
     })


### PR DESCRIPTION
updates example tests so they'll work out of the box with windows path separators

closes #113 