### PR TITLE
fix: add missing method types for moduleContainer

### DIFF
--- a/docs/content/en/api-reference/module-testing.md
+++ b/docs/content/en/api-reference/module-testing.md
@@ -16,7 +16,7 @@ When you write tests for a Nuxt module, you normally expect the module to be ins
 * `method`
   * Type: `String`
   * `required`
-  * Available values are `addModule`, `addPlugin`, `addLayout`, `addErrorLayout`, `addServerMiddleware` and `requireModule`
+  * Available values are `addTemplate`, `extendBuild`, `extendRoutes`, `addModule`, `addPlugin`, `addLayout`, `addErrorLayout`, `addServerMiddleware` and `requireModule`
 * `args`
   * `optional`
   * Additional parameters that are expected to be passed to the tested `method`
@@ -38,7 +38,7 @@ test('should inject plugin', () => {
 * `method`
   * Type: `String`
   * `required`
-  * Available values are `addModule`, `addPlugin`, `addLayout`, `addErrorLayout`, `addServerMiddleware` and `requireModule`
+  * Available values are `addTemplate`, `extendBuild`, `extendRoutes`, `addModule`, `addPlugin`, `addLayout`, `addErrorLayout`, `addServerMiddleware` and `requireModule`
 * `args`
   * `optional`
   * Additional parameters that are expected to be passed to the tested `method`

--- a/docs/content/en/api-reference/module-testing.md
+++ b/docs/content/en/api-reference/module-testing.md
@@ -16,7 +16,7 @@ When you write tests for a Nuxt module, you normally expect the module to be ins
 * `method`
   * Type: `String`
   * `required`
-  * Available values are `addPlugin`, `addLayout`, `addErrorLayout`, `addServerMiddleware` and `requireModule`
+  * Available values are `addModule`, `addPlugin`, `addLayout`, `addErrorLayout`, `addServerMiddleware` and `requireModule`
 * `args`
   * `optional`
   * Additional parameters that are expected to be passed to the tested `method`
@@ -38,7 +38,7 @@ test('should inject plugin', () => {
 * `method`
   * Type: `String`
   * `required`
-  * Available values are `addPlugin`, `addLayout`, `addErrorLayout`, `addServerMiddleware` and `requireModule`
+  * Available values are `addModule`, `addPlugin`, `addLayout`, `addErrorLayout`, `addServerMiddleware` and `requireModule`
 * `args`
   * `optional`
   * Additional parameters that are expected to be passed to the tested `method`

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'fs'
 import { resolve } from 'path'
 import { getNuxt } from './nuxt'
 
-type ModuleContainerMethod = 'addPlugin' | 'addLayout' | 'addErrorLayout' | 'addServerMiddleware' | 'requireModule'
+type ModuleContainerMethod = 'addModule' | 'addPlugin' | 'addLayout' | 'addErrorLayout' | 'addServerMiddleware' | 'requireModule'
 
 export function expectModuleToBeCalledWith (method: ModuleContainerMethod, ...args: any[]) {
   expect(getNuxt().moduleContainer[method]).toBeCalledWith(...args)

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'fs'
 import { resolve } from 'path'
 import { getNuxt } from './nuxt'
 
-type ModuleContainerMethod = 'addModule' | 'addPlugin' | 'addLayout' | 'addErrorLayout' | 'addServerMiddleware' | 'requireModule'
+type ModuleContainerMethod = 'addTemplate' | 'extendBuild' | 'extendRoutes' | 'addModule' | 'addPlugin' | 'addLayout' | 'addErrorLayout' | 'addServerMiddleware' | 'requireModule'
 
 export function expectModuleToBeCalledWith (method: ModuleContainerMethod, ...args: any[]) {
   expect(getNuxt().moduleContainer[method]).toBeCalledWith(...args)


### PR DESCRIPTION
Included the `addModule` option in the [module testing page](https://test-utils.nuxtjs.org/api-reference/module-testing)

fixes #119