### PR TITLE
test: clean up

### DIFF
--- a/test/e2e/browser.test.ts
+++ b/test/e2e/browser.test.ts
@@ -1,9 +1,7 @@
-import { resolve } from 'path'
 import { setupTest, createPage } from '../../src'
 
 describe('browser', () => {
   setupTest({
-    testDir: resolve(__dirname, '..'),
     fixture: 'fixtures/basic',
     browser: true
   })
@@ -17,10 +15,9 @@ describe('browser', () => {
 
 describe('browser type', () => {
   setupTest({
-    testDir: resolve(__dirname, '..'),
     fixture: 'fixtures/basic',
     browserOptions: {
-      // @ts-ignore
+      // @ts-expect-error
       type: 'foo'
     }
   })

--- a/test/fixtures/basic/nuxt.config.js
+++ b/test/fixtures/basic/nuxt.config.js
@@ -1,6 +1,4 @@
 export default {
-  srcDir: __dirname,
-
   modules: [
     '~/modules/module-a'
   ]

--- a/test/fixtures/consola/nuxt.config.js
+++ b/test/fixtures/consola/nuxt.config.js
@@ -3,6 +3,4 @@ import consola from 'consola'
 consola.warn('foo')
 consola.withTag('build').error('bar')
 
-export default {
-  srcDir: __dirname
-}
+export default {}

--- a/test/unit/generate.test.ts
+++ b/test/unit/generate.test.ts
@@ -4,12 +4,8 @@ import { setupTest, getNuxt, expectModuleNotToBeCalledWith, expectFileToBeGenera
 
 describe('generate', () => {
   setupTest({
-    testDir: resolve(__dirname, '..'),
     fixture: 'fixtures/generate',
-    generate: true,
-    config: {
-      rootDir: resolve(__dirname, '../fixtures/generate')
-    }
+    generate: true
   })
 
   test('should not file generated', () => {

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -1,12 +1,9 @@
-import { resolve } from 'path'
 import { setupTest, get, expectModuleToBeCalledWith } from '../../src'
 
 describe('module', () => {
   setupTest({
-    testDir: resolve(__dirname, '..'),
-    build: true,
-    server: true,
-    fixture: 'fixtures/basic'
+    fixture: 'fixtures/basic',
+    server: true
   })
 
   test('request page', async () => {
@@ -30,16 +27,14 @@ describe('module', () => {
 
 describe('setup with waitFor', () => {
   setupTest({
-    testDir: resolve(__dirname, '..'),
-    build: true,
     fixture: 'fixtures/basic',
+    build: true,
     waitFor: 100
   })
 })
 
 describe('server', () => {
   setupTest({
-    testDir: resolve(__dirname, '..'),
     fixture: 'fixtures/basic'
   })
 


### PR DESCRIPTION
Removed unnecessary code in test and fixture files.

For those who look for usage inside `test` folder, it will be easier to read and to understand how all works.