### PR TITLE
fix: use `join` instead of `resolve` for paths related with `fixture` option

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs'
-import { resolve } from 'path'
+import { join } from 'path'
 import { getNuxt } from './nuxt'
 
 type ModuleContainerMethod = 'addTemplate' | 'extendBuild' | 'extendRoutes' | 'addModule' | 'addPlugin' | 'addLayout' | 'addErrorLayout' | 'addServerMiddleware' | 'requireModule'
@@ -13,9 +13,9 @@ export function expectModuleNotToBeCalledWith (method: ModuleContainerMethod, ..
 }
 
 export function expectFileToBeGenerated (path: string) {
-  expect(existsSync(resolve(getNuxt().options.generate.dir, path))).toBe(true)
+  expect(existsSync(join(getNuxt().options.generate.dir, path))).toBe(true)
 }
 
 export function expectFileNotToBeGenerated (path: string) {
-  expect(existsSync(resolve(getNuxt().options.generate.dir, path))).toBe(false)
+  expect(existsSync(join(getNuxt().options.generate.dir, path))).toBe(false)
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'path'
+import { join } from 'path'
 import defu from 'defu'
 import { NuxtConfig, NuxtOptions } from '@nuxt/types'
 import type { Browser, LaunchOptions } from 'playwright'
@@ -59,7 +59,7 @@ let currentContext: NuxtTestContext
 
 export function createContext (options: Partial<NuxtTestOptions>): NuxtTestContext {
   const _options: Partial<NuxtTestOptions> = defu(options, {
-    testDir: resolve(process.cwd(), 'test'),
+    testDir: join(process.cwd(), 'test'),
     fixture: 'fixture',
     configFile: 'nuxt.config',
     setupTimeout: 60000,

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs'
-import { resolve } from 'path'
+import { join } from 'path'
 import { getContext } from './context'
 
 export async function loadNuxt () {
@@ -11,9 +11,9 @@ export async function loadNuxt () {
 
 const isNuxtApp = (dir: string) => {
   return existsSync(dir) && (
-    existsSync(resolve(dir, 'pages')) ||
-    existsSync(resolve(dir, 'nuxt.config.js')) ||
-    existsSync(resolve(dir, 'nuxt.config.ts'))
+    existsSync(join(dir, 'pages')) ||
+    existsSync(join(dir, 'nuxt.config.js')) ||
+    existsSync(join(dir, 'nuxt.config.ts'))
   )
 }
 
@@ -22,7 +22,7 @@ const resolveRootDir = () => {
 
   const dirs = [
     options.rootDir,
-    resolve(options.testDir, options.fixture),
+    join(options.testDir, options.fixture),
     process.cwd()
   ]
 
@@ -53,7 +53,7 @@ export async function loadFixture () {
 
   if (!options.config.buildDir) {
     const randomId = Math.random().toString(36).substr(2, 8)
-    options.config.buildDir = resolve(options.rootDir, '.nuxt', randomId)
+    options.config.buildDir = join(options.rootDir, '.nuxt', randomId)
   }
 }
 


### PR DESCRIPTION
## Problem

Documented behaviour:

`testDir`, default value: '~~/test'
`fixture`, "a fixture directory (under `testDir`)", default value: 'fixture'
`rootDir`, default value: \<testDir>/\<fixture>

All works as expected if `setupTest` is called this way:

```js
setupTest({
  fixture: 'some-fixture'
})

rootDir === '<process.cwd()>/test/fixture/some-fixture' // true
```

But it will not work with leading slash:

```js
setupTest({
  fixture: '/some-fixture',
})

rootDir === '/some-fixture' // true
```

`path.resolve` is called inside `resolveRootDir` which returns `rootDir` value.

## Solution

`path.join` instead of `path.resolve` does the right job.

By the way, `expectFileToBeGenerated` and `expectFileNotToBeGenerated` have the same issue. Calling `expectFileToBeGenerated('/index.html')` will not check if the file exists inside `generate.dir`, but will look for it at system root. Again `path.join` solves the problem.

Elsewhere `path.resolve` works as expected and there is no need for any change. In the other hand, `path.join` is enough, `nuxt.ts` file would have one import less, and also `path.join` has shorter name, this makes bundle size smaller. Minor details, but it is fun to keep them in mind.

## Alternative Solution

Update docs with a warning to avoid leading slash or to use absolute paths. Also possible.