### PR TITLE
fix: close server explicitly

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -2,6 +2,7 @@ import type { RequestListener } from 'http'
 import { join } from 'path'
 import defu from 'defu'
 import { NuxtConfig, NuxtOptions } from '@nuxt/types'
+import type { Listener } from 'listhen'
 import type { Browser, LaunchOptions } from 'playwright'
 
 export interface NuxtTestOptions {
@@ -31,31 +32,33 @@ export interface NuxtTestOptions {
   server: boolean
 }
 
+export interface Nuxt {
+  server: {
+    app: RequestListener,
+  },
+  options: NuxtOptions
+  ready: () => any
+  close: (callback?: Function) => any
+  resolver: any
+  moduleContainer: any
+  resolveAlias(path: string): string
+  resolvePath(path: string, opts?: any): string
+  renderRoute(...args: any[]): any
+  renderAndGetWindow(url: string, opts?: any, config?: any): any
+}
+
 export interface NuxtTestContext {
-  options: NuxtTestOptions
+  options: Partial<NuxtTestOptions>
 
-  nuxt?: {
-    server: {
-      app: RequestListener,
-    },
-    options: NuxtOptions
-    ready: () => any
-    close: (callback?: Function) => any
-    resolver: any
-    moduleContainer: any
-    resolveAlias(path: string): string
-    resolvePath(path: string, opts?: any): string
-    renderRoute(...args: any[]): any
-    renderAndGetWindow(url: string, opts?: any, config?: any): any
-  }
-
-  browser?: Browser
-
-  url?: string
+  nuxt?: Nuxt
 
   builder?: {
     build: () => any
   }
+
+  listener?: Listener
+
+  browser?: Browser
 }
 
 let currentContext: NuxtTestContext

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,11 +6,9 @@ import { getContext } from './context'
 export async function listen () {
   const ctx = getContext()
   const { server } = ctx.options.config
-  const { url } = await listhen(ctx.nuxt.server.app, {
+  ctx.listener = await listhen(ctx.nuxt.server.app, {
     ...(server?.port && { port: Number(server?.port) })
   })
-
-  ctx.url = url
 }
 
 export function get<T> (path: string, options?: FetchOptions) {
@@ -20,9 +18,9 @@ export function get<T> (path: string, options?: FetchOptions) {
 export function url (path: string) {
   const ctx = getContext()
 
-  if (!ctx.url) {
+  if (!ctx.listener) {
     throw new Error('server is not enabled')
   }
 
-  return joinURL(ctx.url, path)
+  return joinURL(ctx.listener.url, path)
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -21,6 +21,10 @@ export function setupTest (options: Partial<NuxtTestOptions>) {
       await ctx.nuxt.close()
     }
 
+    if (ctx.listener) {
+      await ctx.listener.close()
+    }
+
     if (ctx.browser) {
       await ctx.browser.close()
     }

--- a/test/unit/server.test.ts
+++ b/test/unit/server.test.ts
@@ -1,0 +1,39 @@
+import { RequestListener } from 'http'
+import { listen as listhen, Listener } from 'listhen'
+import { listen } from '../../src/server'
+import { getContext, NuxtTestContext, Nuxt } from '../../src/context'
+
+const mockHandle = jest.fn() as RequestListener
+const mockNuxt = { server: { app: mockHandle } } as Nuxt
+const mockContext: Partial<NuxtTestContext> = {
+  nuxt: mockNuxt
+}
+
+jest.mock('../../src/context', () => ({
+  getContext: () => mockContext
+}))
+
+const mockListhen = listhen as jest.MockedFunction<typeof listhen>
+
+jest.mock('listhen')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockContext.options = {}
+})
+
+describe('server', () => {
+  test('adds listener property to the context', async () => {
+    const mockListener = {} as Listener
+    mockListhen.mockResolvedValue(mockListener)
+
+    const context = getContext()
+    context.options = {
+      config: { server: {} }
+    }
+
+    await listen()
+
+    expect(context.listener).toBe(mockListener)
+  })
+})


### PR DESCRIPTION
After migration to `listhen` (#129), server is not closed after tests run. Therefore, Jest throws “A worker process has failed to exit gracefully…” error. To recreate, try building the library and importing `setupTest` to a test from `dist`.

`listhen` has close on exit signal feature, but for some reason it does not work in Jest environment. The test below will throw the same error, because listener is not closing:

```js
import { listen } from 'listhen'

test('listhen', async () => {
  await listen((req, res) => { res.end(req.url) })
  // ...
})
```

The idea of auto closing server inspired me and I thought perhaps Nuxt could be also closed on exit signal. Did not manage to make this work and also found out that server is not closing. (I was trying out 'beforeExit' event too. No luck.)

Seems like everything should be closed explicitly.