### PR TITLE
feat!: add `randomBuildDir` option

### DIFF
--- a/docs/content/en/api-reference/setup.md
+++ b/docs/content/en/api-reference/setup.md
@@ -71,21 +71,12 @@ The path to the Nuxt application that will be used in the tests.
 * Type: `string`
 * Default: `<testDir>/<fixture>`
 
-### Build directory
+##### randomBuildDir
 
-`setupTest` will create a random build directory to avoid race conditions and conflicts between tests which run in parallel. The default template is: `<rootDir>/.nuxt/<randomID>`.
+To avoid conflicts between concurrent tests, a new random [build directory](https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-builddir) will be created each time `setupTest` is called.
 
-If `buildDir` is set in `nuxt.config`, the value will be used instead of random one.
-
-Build directory can be also set in `config` options:
-
-```js
-setupTest({
-  config: {
-    buildDir: 'nuxt-build',
-  }
-})
-```
+* Type: `boolean`
+* Default: `true` (ignored if [`build`](#build) step is not enabled)
 
 ##### randomPort
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,6 +12,7 @@ export interface NuxtTestOptions {
   rootDir: string
   config: NuxtConfig
 
+  randomBuildDir: boolean
   randomPort: boolean
 
   build: boolean
@@ -65,6 +66,7 @@ export function createContext (options: Partial<NuxtTestOptions>): NuxtTestConte
     testDir: join(process.cwd(), 'test'),
     fixture: 'fixture',
     configFile: 'nuxt.config',
+    randomBuildDir: true,
     randomPort: true,
     setupTimeout: 60000,
     server: options.browser,

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'fs'
 import { join } from 'path'
 import { getContext } from './context'
+import { randomId } from './utils'
 
 export async function loadNuxt () {
   const ctx = getContext()
@@ -51,9 +52,8 @@ export async function loadFixture () {
     options.config.rootDir = options.rootDir
   }
 
-  if (!options.config.buildDir) {
-    const randomId = Math.random().toString(36).substr(2, 8)
-    options.config.buildDir = join(options.rootDir, '.nuxt', randomId)
+  if (options.randomBuildDir && options.build) {
+    options.config.buildDir = join(options.config.buildDir || '.nuxt', randomId())
   }
 
   if (options.randomPort && options.server) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,3 @@
+export const randomId = () => {
+  return Date.now().toString(36) + '-' + Math.random().toString(36).substr(2, 8)
+}

--- a/test/unit/__snapshots__/context.test.ts.snap
+++ b/test/unit/__snapshots__/context.test.ts.snap
@@ -10,6 +10,7 @@ Object {
     "config": Object {},
     "configFile": "nuxt.config",
     "fixture": "fixture",
+    "randomBuildDir": true,
     "randomPort": true,
     "server": undefined,
     "setupTimeout": 60000,

--- a/test/unit/fixture.test.ts
+++ b/test/unit/fixture.test.ts
@@ -1,3 +1,4 @@
+import { join } from 'path'
 import { loadFixture } from '../../src/nuxt'
 import { getContext, NuxtTestContext } from '../../src/context'
 
@@ -5,20 +6,75 @@ const defaults = {
   testDir: 'test',
   fixture: 'fixtures/basic',
   randomPort: true,
+  randomBuildDir: true,
+  build: true,
   server: true
 }
 
-let mockContext: Partial<NuxtTestContext> = {}
+const mockContext: Partial<NuxtTestContext> = {}
 
 jest.mock('../../src/context', () => ({
   getContext: () => mockContext
 }))
 
+jest.mock('../../src/utils', () => ({
+  randomId: () => 'test1234'
+}))
+
 beforeEach(() => {
-  mockContext = {}
+  mockContext.options = {}
 })
 
 describe('fixture', () => {
+  describe('randomBuildDir', () => {
+    test('by default', async () => {
+      const context = getContext()
+      context.options = {
+        ...defaults
+      }
+
+      await loadFixture()
+
+      expect(context.options.config.buildDir).toBe(join('.nuxt', 'test1234'))
+    })
+
+    test('if `buildDir` option is set', async () => {
+      const context = getContext()
+      context.options = {
+        ...defaults,
+        config: { buildDir: 'nuxt-build' }
+      }
+
+      await loadFixture()
+
+      expect(context.options.config.buildDir).toBe(join('nuxt-build', 'test1234'))
+    })
+
+    test('if `randomBuildDir: false` is set', async () => {
+      const context = getContext()
+      context.options = {
+        ...defaults,
+        randomBuildDir: false
+      }
+
+      await loadFixture()
+
+      expect(context.options.config.buildDir).toBeUndefined()
+    })
+
+    test('if `build: false` is set', async () => {
+      const context = getContext()
+      context.options = {
+        ...defaults,
+        build: false
+      }
+
+      await loadFixture()
+
+      expect(context.options.config.buildDir).toBeUndefined()
+    })
+  })
+
   describe('randomPort', () => {
     test('by default', async () => {
       const context = getContext()

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,0 +1,13 @@
+import { randomId } from '../../src/utils'
+
+describe('randomId', () => {
+  test('generates 1,000,000 unique IDs', () => {
+    const ids = new Set<string>()
+    const count = 10 ** 6
+    for (let i = 0; i < count; ++i) {
+      ids.add(randomId())
+    }
+
+    expect(ids.size).toEqual(count)
+  })
+})


### PR DESCRIPTION
It would be useful to have a possibility to disable random `buildDir` explicitly.

Current:
* `buildDir` is patched with random string by default, but it will be implicitly not patched if custom `buildDir` is set inside `nuxt.config` file or `config` overrides has `buildDir` value
* there is no possibility to disable random default
* there is no possibility to add random part for a custom `buildDir`

Proposed:
* `buildDir` is always randomised (predictable)
* random part will be disabled if `randomBuildDir: false` is set (explicit)

**Use case.** If testing an app, one would be able to build it using a `package.json` script and run tests with `build: false` option set inside `setupTest`. There is no need to build the app with each `setupTest`, this makes the tests suite run significantly faster.

Also proposed implementation is easier to document and to use, because of explicit configuration and predictable behaviour.

**Breaking.** If this PR is merged, previous behaviour can be achieved like this:
```js
setupTest({
  build: true,
  randomBuildDir: false
})
```

**Testing, debugging.** `randomId` was factored out for better testability. `Date.now()` segment was added to make random directories sortable. This helps to find the recent build easier (useful for debugging).

**Types.** `options` object is always partial.