### PR TITLE
feat!: add `randomPort` option

### DIFF
--- a/docs/content/en/api-reference/setup.md
+++ b/docs/content/en/api-reference/setup.md
@@ -87,6 +87,14 @@ setupTest({
 })
 ```
 
+##### randomPort
+
+The test server will listen on a new random port each time `setupTest` is called. If disabled, the server will try to use [`server.port`](https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-server) value.
+
+* Type: `boolean`
+* Default: `true` (ignored if [`server`](#server) is not enabled)
+
+
 ### Setup timings
 
 #### setupTimeout

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,6 +12,8 @@ export interface NuxtTestOptions {
   rootDir: string
   config: NuxtConfig
 
+  randomPort: boolean
+
   build: boolean
   generate: boolean
 
@@ -63,6 +65,7 @@ export function createContext (options: Partial<NuxtTestOptions>): NuxtTestConte
     testDir: join(process.cwd(), 'test'),
     fixture: 'fixture',
     configFile: 'nuxt.config',
+    randomPort: true,
     setupTimeout: 60000,
     server: options.browser,
     build: options.browser || options.server,

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -55,6 +55,13 @@ export async function loadFixture () {
     const randomId = Math.random().toString(36).substr(2, 8)
     options.config.buildDir = join(options.rootDir, '.nuxt', randomId)
   }
+
+  if (options.randomPort && options.server) {
+    options.config.server = {
+      ...options.config.server,
+      port: 0
+    }
+  }
 }
 
 export async function loadNuxtPackage (name: string = 'nuxt') {

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,10 +5,8 @@ import { getContext } from './context'
 
 export async function listen () {
   const ctx = getContext()
-  const { server } = ctx.options.config
-  ctx.listener = await listhen(ctx.nuxt.server.app, {
-    ...(server?.port && { port: Number(server?.port) })
-  })
+  const port = Number(ctx.options.config.server?.port)
+  ctx.listener = await listhen(ctx.nuxt.server.app, { port: { port, random: !port } })
 }
 
 export function get<T> (path: string, options?: FetchOptions) {

--- a/test/unit/__snapshots__/context.test.ts.snap
+++ b/test/unit/__snapshots__/context.test.ts.snap
@@ -10,6 +10,7 @@ Object {
     "config": Object {},
     "configFile": "nuxt.config",
     "fixture": "fixture",
+    "randomPort": true,
     "server": undefined,
     "setupTimeout": 60000,
     "testDir": "foo",

--- a/test/unit/fixture.test.ts
+++ b/test/unit/fixture.test.ts
@@ -1,0 +1,71 @@
+import { loadFixture } from '../../src/nuxt'
+import { getContext, NuxtTestContext } from '../../src/context'
+
+const defaults = {
+  testDir: 'test',
+  fixture: 'fixtures/basic',
+  randomPort: true,
+  server: true
+}
+
+let mockContext: Partial<NuxtTestContext> = {}
+
+jest.mock('../../src/context', () => ({
+  getContext: () => mockContext
+}))
+
+beforeEach(() => {
+  mockContext = {}
+})
+
+describe('fixture', () => {
+  describe('randomPort', () => {
+    test('by default', async () => {
+      const context = getContext()
+      context.options = {
+        ...defaults
+      }
+
+      await loadFixture()
+
+      expect(context.options.config.server?.port).toBe(0)
+    })
+
+    test('if `server.port` option is set', async () => {
+      const context = getContext()
+      context.options = {
+        ...defaults,
+        config: { server: { port: 5050 } }
+      }
+
+      await loadFixture()
+
+      expect(context.options.config.server?.port).toBe(0)
+    })
+
+    test('if `randomPort: false` is set', async () => {
+      const context = getContext()
+      context.options = {
+        ...defaults,
+        config: { server: { port: 5050 } },
+        randomPort: false
+      }
+
+      await loadFixture()
+
+      expect(context.options.config.server.port).toBe(5050)
+    })
+
+    test('if `server: false` is set', async () => {
+      const context = getContext()
+      context.options = {
+        ...defaults,
+        server: false
+      }
+
+      await loadFixture()
+
+      expect(context.options.config.server).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
It would be also useful to have `randomPort` option. Motivation is similar to `randomBuildDir` #137

Current:
* test server is trying to listen on `config.server.port`, random port is a fall back
* it is not possible to choose explicitly which value should be used in a test

Proposed:
* server always listens on random port (predictable)
* if `randomPort: false` is set, custom port is used (explicit)

**Use case.** For example, a fixture could have `config.server.port` set. One test ignores that. Another test has `randomPort: false` set and tries to listen on that particular port. There is no need to have separate fixtures or any additional logic. Inspired by real use case nuxt-community/auth-module#868 (see test file).

**Breaking.** If this PR is merged, previous implicit behaviour gets broken. Easy to fix it:
```js
setupTest({
  server: true,
  config: { server: { port: 5050 } },
  randomPort: false
})
```

**Types.** `options` object is always partial. Factored out `Nuxt` interface is useful in test.