### PR TITLE
fix(types): remove not used `generateOptions`

### DIFF
--- a/docs/content/en/api-reference/setup.md
+++ b/docs/content/en/api-reference/setup.md
@@ -126,14 +126,6 @@ Whether to run generate pre-rendered HTML files for the application.
 * Type: `boolean`
 * Default: `false`
   
-<!-- #### generateOptions
-
-* Type: `object` with the following properties
-  - **build**: boolean
-  - **init**: boolean
-  
-* Default: `{}` -->
-
 #### browser
 
 Under the hood, Nuxt test utils uses [`playwright`](https://playwright.dev/) to carry out browser testing. If this option is set, a browser will be launched and can be controlled in the subsequent test suite. (More info can be found [here](/api-reference/browser-testing).)

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,12 +12,7 @@ export interface NuxtTestOptions {
   config: NuxtConfig
 
   build: boolean
-
   generate: boolean
-  generateOptions: {
-    build: boolean
-    init: boolean
-  }
 
   setupTimeout: number
   waitFor: number

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,13 +1,12 @@
 import { getContext } from './context'
-import { loadNuxtPackage, getNuxt } from './nuxt'
+import { loadNuxtPackage } from './nuxt'
 
 export async function generate () {
-  const { options } = getContext()
-  const nuxt = getNuxt()
+  const { nuxt } = getContext()
   const { Builder, Generator } = await loadNuxtPackage()
 
   const builder = new Builder(nuxt)
   const generator = new Generator(nuxt, builder)
 
-  await generator.generate(options.generate)
+  await generator.generate()
 }


### PR DESCRIPTION
Perhaps it makes sense to remove `generateOptions` to improve typings.

`options.generate` was passed to generator instead of `options. generateOptions`, it was not possible to use it. That’s why this PR is only fixing typings.

Of course, it can be brought back later if there is a use case.