### PR TITLE
refactor: improve nuxt app validation

### DIFF
--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -1,7 +1,6 @@
-import { existsSync } from 'fs'
-import { join, resolve } from 'path'
+import { join } from 'path'
 import { getContext } from './context'
-import { randomId } from './utils'
+import { ensureNuxtApp, randomId } from './utils'
 
 export async function loadNuxt () {
   const ctx = getContext()
@@ -10,18 +9,10 @@ export async function loadNuxt () {
   ctx.nuxt = new Nuxt(ctx.options.config)
 }
 
-const isNuxtApp = (dir: string) => {
-  return existsSync(resolve(dir, 'pages')) ||
-    existsSync(resolve(dir, 'nuxt.config.js')) ||
-    existsSync(resolve(dir, 'nuxt.config.ts'))
-}
-
 export async function loadFixture () {
   const { options } = getContext()
 
-  if (!isNuxtApp(options.rootDir)) {
-    throw new Error('Invalid nuxt app. (Please explicitly set `options.rootDir` pointing to a valid nuxt app)')
-  }
+  await ensureNuxtApp(options.rootDir)
 
   const { loadNuxtConfig } = await loadNuxtPackage()
   options.config = await loadNuxtConfig({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,22 @@
+import { readdir } from 'fs/promises'
+import { resolve } from 'path'
+
+const nuxtDir = ['nuxt.config.js', 'nuxt.config.ts', 'pages']
+const fixtureError = 'Make sure \'rootDir\' or \'fixture\' option is pointing to a location which at least contains \'nuxt.config\' file or \'pages\' directory.'
+
+export const ensureNuxtApp = async (dir: string) => {
+  const targetDir = await readdir((resolve(dir)))
+    .catch((_err) => {
+      throw new Error(`Cannot read from '${resolve(dir)}'. ${fixtureError}`)
+    })
+
+  const isNuxtAppFound = nuxtDir.some(path => targetDir.includes(path))
+
+  if (!isNuxtAppFound) {
+    throw new Error(`Cannot find Nuxt app at '${resolve(dir)}'. ${fixtureError}`)
+  }
+}
+
 export const randomId = () => {
   return Date.now().toString(36) + '-' + Math.random().toString(36).substr(2, 8)
 }

--- a/test/unit/fixture.test.ts
+++ b/test/unit/fixture.test.ts
@@ -3,7 +3,7 @@ import { loadFixture } from '../../src/nuxt'
 import { getContext, NuxtTestContext } from '../../src/context'
 
 const defaults = {
-  rootDir: 'test/fixtures/generate',
+  rootDir: '.',
   randomPort: true,
   randomBuildDir: true,
   build: true,
@@ -17,7 +17,8 @@ jest.mock('../../src/context', () => ({
 }))
 
 jest.mock('../../src/utils', () => ({
-  randomId: () => 'test1234'
+  randomId: () => 'mock-random-string',
+  ensureNuxtApp: () => Promise.resolve()
 }))
 
 beforeEach(() => {
@@ -34,7 +35,7 @@ describe('fixture', () => {
 
       await loadFixture()
 
-      expect(context.options.config.buildDir).toBe(join('.nuxt', 'test1234'))
+      expect(context.options.config.buildDir).toBe(join('.nuxt', 'mock-random-string'))
     })
 
     test('if `buildDir` option is set', async () => {
@@ -46,7 +47,7 @@ describe('fixture', () => {
 
       await loadFixture()
 
-      expect(context.options.config.buildDir).toBe(join('nuxt-build', 'test1234'))
+      expect(context.options.config.buildDir).toBe(join('nuxt-build', 'mock-random-string'))
     })
 
     test('if `randomBuildDir: false` is set', async () => {

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,4 +1,27 @@
-import { randomId } from '../../src/utils'
+import { readdir } from 'fs/promises'
+import { ensureNuxtApp, randomId } from '../../src/utils'
+
+const mockReaddir = readdir as jest.MockedFunction<typeof readdir>
+
+jest.mock('fs/promises')
+
+describe('isNuxtAppDir', () => {
+  // @ts-ignore
+  mockReaddir.mockReset().mockResolvedValue(['pages'])
+  test('stays silent if nuxt app is discovered', async () => {
+    await expect(ensureNuxtApp('.')).resolves.not.toThrow()
+  })
+
+  test('throws if nuxt app is NOT found', async () => {
+    mockReaddir.mockReset().mockResolvedValue([])
+    await expect(ensureNuxtApp('.')).rejects.toThrow('Cannot find')
+  })
+
+  test('throws if directory is unreachable', async () => {
+    mockReaddir.mockReset().mockRejectedValue(new Error('Mock error'))
+    await expect(ensureNuxtApp('.')).rejects.toThrow('Cannot read')
+  })
+})
 
 describe('randomId', () => {
   test('generates 1,000,000 unique IDs', () => {


### PR DESCRIPTION
While rebasing #134, I though the Nuxt app validation could be simplified.

Currently: always three calls to the file system.
Proposed: just one `readdir` call and validation in memory. Array’s `.some()` should help to return early.

In some exotic case, `pages` could also be a file. It is possible to detect this using `Dirent`s, but perhaps that’s too much for this small library.

Validation logic is factored out to improve testability.