### PR TITLE
chore(deps): remove `babel-jest`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@babel/plugin-transform-runtime": "^7.14.5",
     "@babel/preset-env": "^7.14.5",
     "@babel/preset-typescript": "^7.14.5",
-    "babel-jest": "^27.0.6",
     "consola": "^2.15.3",
     "defu": "^5.0.0",
     "listhen": "^0.2.4",


### PR DESCRIPTION
`babel-jest` is `jest`'s dependency. `jest` takes care to install and makes sure to pick correct version. It is not possible to know in advance if user has Jest v26 or v27.

Might be there is no harm to declare it as a dependency, but there is no need or gain too. This library does not import from `babel-jest`.