### PR TITLE
test: improve `ensureNuxtApp` test

### DIFF
--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -5,20 +5,19 @@ const mockReaddir = readdir as jest.MockedFunction<typeof readdir>
 
 jest.mock('fs/promises')
 
-describe('isNuxtAppDir', () => {
-  // @ts-ignore
-  mockReaddir.mockReset().mockResolvedValue(['pages'])
+describe('ensureNuxtApp', () => {
   test('stays silent if nuxt app is discovered', async () => {
+    mockReaddir.mockResolvedValue(['pages'] as jest.ResolvedValue<string[]>)
     await expect(ensureNuxtApp('.')).resolves.not.toThrow()
   })
 
   test('throws if nuxt app is NOT found', async () => {
-    mockReaddir.mockReset().mockResolvedValue([])
+    mockReaddir.mockResolvedValue([])
     await expect(ensureNuxtApp('.')).rejects.toThrow('Cannot find')
   })
 
   test('throws if directory is unreachable', async () => {
-    mockReaddir.mockReset().mockRejectedValue(new Error('Mock error'))
+    mockReaddir.mockRejectedValue(new Error('Mock error'))
     await expect(ensureNuxtApp('.')).rejects.toThrow('Cannot read')
   })
 })


### PR DESCRIPTION
@ricardogobbosouza Thanks for solution. It is better without `@ts-ignore`.

Just double checked, in this case `readdir` will return an array. `string[]` here looks better for me.