### PR TITLE
refactor: launch server on demand

### DIFF
--- a/docs/content/en/api-reference/server-testing.md
+++ b/docs/content/en/api-reference/server-testing.md
@@ -8,8 +8,6 @@ category: Writing tests
 
 Nuxt test utils exposes a number of useful methods you can use when testing a Nuxt application.
 
-These helper methods require that you pass `{ server: true }` as an option to `setupTest` ([more info](/api-reference/setup#features-to-enable)).
-
 ## get
 
 You can get a response to a server-rendered page with `get`.
@@ -20,12 +18,12 @@ You can get a response to a server-rendered page with `get`.
 import { get, setupTest } from '@nuxt/test-utils'
 
 describe('ssr', () => {
-  setupTest({ server: true })
+  setupTest()
 
-  it('renders the index page', async () => {
-    const { body } = await get('/')
-
-    expect(body).toContain('<a>A Link</a>')
+  test('renders the index page', async () => {
+    const html = await get('/')
+    
+    expect(html).toContain('<a>A Link</a>')
   })
 })
 ```
@@ -40,11 +38,11 @@ This helper simply returns the full URL for a given page (including the port the
 import { url, setupTest } from '@nuxt/test-utils'
 
 describe('ssr', () => {
-  setupTest({ server: true })
+  setupTest()
 
-  it('renders the index page', async () => {
-    const thePage = url('/page')
-    // is something like 'http://localhost:6840/page'
+  test('renders the index page', async () => {
+    console.log(await url('/page'))
+    // will print something like 'http://localhost:68420/page'
   })
 })
 ```

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,6 +1,6 @@
 import type { Browser, BrowserContextOptions } from 'playwright'
 import { getContext } from './context'
-import { url } from './server'
+import { url as getUrl } from './server'
 
 export async function createBrowser () {
   const ctx = getContext()
@@ -37,7 +37,8 @@ export async function createPage (path?: string, options?: BrowserContextOptions
   const page = await browser.newPage(options)
 
   if (path) {
-    await page.goto(url(path))
+    const url = await getUrl(path)
+    await page.goto(url)
   }
 
   return page

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,15 +9,15 @@ export async function listen () {
   ctx.listener = await listhen(ctx.nuxt.server.app, { port: { port, random: !port } })
 }
 
-export function get<T> (path: string, options?: FetchOptions) {
-  return $fetch<T>(url(path), options)
+export async function get<T> (path: string, options?: FetchOptions) {
+  return $fetch<T>(await url(path), options)
 }
 
-export function url (path: string) {
+export async function url (path: string) {
   const ctx = getContext()
 
-  if (!ctx.listener) {
-    throw new Error('server is not enabled')
+  if (!ctx.listener?.url) {
+    await listen()
   }
 
   return joinURL(ctx.listener.url, path)

--- a/test/e2e/browser.test.ts
+++ b/test/e2e/browser.test.ts
@@ -2,8 +2,7 @@ import { setupTest, createPage } from '../../src'
 
 describe('browser', () => {
   setupTest({
-    rootDir: 'test/fixtures/basic',
-    browser: true
+    rootDir: 'test/fixtures/basic'
   })
 
   test('should render page', async () => {

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -2,8 +2,7 @@ import { setupTest, get, expectModuleToBeCalledWith } from '../../src'
 
 describe('module', () => {
   setupTest({
-    rootDir: 'test/fixtures/basic',
-    server: true
+    rootDir: 'test/fixtures/basic'
   })
 
   test('request page', async () => {
@@ -30,15 +29,5 @@ describe('setup with waitFor', () => {
     rootDir: 'test/fixtures/basic',
     build: true,
     waitFor: 100
-  })
-})
-
-describe('server', () => {
-  setupTest({
-    rootDir: 'test/fixtures/basic'
-  })
-
-  test('should be error if server not enabled', () => {
-    expect(() => get('/')).toThrowError('server is not enabled')
   })
 })


### PR DESCRIPTION
To enable helpers like `get` or `createPage`, documentation is reminding to set `{ server: true, browser: true }`.

`get` throws an error if server is not listening. The logic inside `browser.ts` is different, [a browser is created](https://github.com/nuxt/test-utils/blob/9b239ac1550118262440c20805ceca6fc69c14fc/src/browser.ts#L29) if it is not found in the context.

This inconsistence was bugging me for some time. What if both (server or browser) would be launched automagically then some helpers requires them? The helpers would be much more helpful, isn’t it? It is obvious what user is expecting:

```js
setupTest()
test('some test', async () => {
  const html = await get('/')

////

setupTest()
test('some test', async () => {
  const page = await createPage('/')
```

One tiny problem – `build: true` should be set to make this work. Exchanging `server: true` for `build: true` does not look like any improvement. I think defaults should be adjusted. See #151.

PS Tests will work only after #151 is merged. I made it like this on purpose.