### PR TITLE
refactor!: change defaults `build: true`

### DIFF
--- a/docs/content/en/api-reference/browser-testing.md
+++ b/docs/content/en/api-reference/browser-testing.md
@@ -8,8 +8,6 @@ category: Writing tests
 
 Under the hood, Nuxt test utils uses [`playwright`](https://playwright.dev/) to carry out browser testing.
 
-These helper methods require that you pass `{ browser: true }` as an option to `setupTest` ([more info](/api-reference/setup#features-to-enable)).
-
 ## createPage
 
 You can initiate a browser session for a given page with `createPage`.
@@ -22,9 +20,9 @@ You can find out more about the properties and methods on the page object [in th
 import { createPage, setupTest } from '@nuxt/test-utils'
 
 describe('browser', () => {
-  setupTest({ browser: true })
+  setupTest()
 
-  it('renders the index page', async () => {
+  test('renders the index page', async () => {
     const page = await createPage('/')
     const html = await page.innerHTML('body')
 

--- a/docs/content/en/api-reference/module-testing.md
+++ b/docs/content/en/api-reference/module-testing.md
@@ -24,11 +24,20 @@ When you write tests for a Nuxt module, you normally expect the module to be ins
 Expect a specific method to be triggered while installing a module.
 
 ```js
-test('should inject plugin', () => {
-  expectModuleToBeCalledWith('addPlugin', {
-    src: expect.stringMatching(/templates[\\/]plugin.js/),
-    fileName: 'myPlugin.js',
-    options: getNuxt().options.myModule
+import { setupTest, expectModuleToBeCalledWith } from '@nuxt/test-utils'
+
+describe('browser', () => {
+  setupTest(
+    rootDir: 'path/to/fixture',
+    build: false
+  )
+
+  test('should inject plugin', () => {
+    expectModuleToBeCalledWith('addPlugin', {
+      src: expect.stringMatching(/templates[\\/]plugin.js/),
+      fileName: 'myPlugin.js',
+      options: getNuxt().options.myModule
+    })
   })
 })
 ```

--- a/docs/content/en/api-reference/setup.md
+++ b/docs/content/en/api-reference/setup.md
@@ -91,19 +91,19 @@ An additional aount of time (in milliseconds) to wait after setting up the test 
 
 ### Features to enable
 
+#### build
+
+Whether to run a separate build step.
+
+* Type: `boolean`
+* Default: `true`
+
 #### server
 
 Whether to launch a server to respond to requests in the test suite.
 
 * Type: `boolean`
 * Default: `false`
-
-#### build
-
-Whether to run a separate build step.
-
-* Type: `boolean`
-* Default: `false` (`true` if `browser` or `server` is enabled)
   
 #### generate
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -65,8 +65,8 @@ export function createContext (options: Partial<NuxtTestOptions> = {}): NuxtTest
     randomBuildDir: true,
     randomPort: true,
     setupTimeout: 60000,
+    build: true,
     server: options.browser,
-    build: options.browser || options.server,
     browserOptions: {
       type: 'chromium'
     }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -41,7 +41,7 @@ export function setupTest (options: Partial<NuxtTestOptions>) {
       await ctx.nuxt.ready()
     }
 
-    if (ctx.options.build) {
+    if (ctx.options.build && !ctx.options.generate) {
       await build()
     }
 

--- a/test/unit/__snapshots__/context.test.ts.snap
+++ b/test/unit/__snapshots__/context.test.ts.snap
@@ -6,7 +6,7 @@ Object {
     "browserOptions": Object {
       "type": "chromium",
     },
-    "build": undefined,
+    "build": true,
     "configFile": "nuxt.config",
     "randomBuildDir": true,
     "randomPort": true,


### PR DESCRIPTION
`build: true` might be better default:

One. It would make helpers more helpful (see #150).

Two. In general `setupTest` utility is helping to set up end-to-end tests. The artefacts created by building or generating apps/fixtures are the actual fixtures which are being put under tests. Without `build` step there is nothing to test. I see only two exceptions: a) the user might build the app before launching test, in this case `build: false` is necessary also with current defaults; b) the `moduleContainer` assertions are used (these work without `build` step).

The `moduleContainer` assertions work with `build: true`. It is only the matter of speed. `build: false` would make them fast again. Perhaps this could be the solution for now. I have better idea, but that’s another PR.

~~`generator` logic got improved a bit. I was checking if there are no side effects. If builder is created by default, better to reuse it.~~