### PR TITLE
refactor: reuse builder and build logic

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,12 +1,16 @@
 import { getContext } from './context'
 import { loadNuxtPackage } from './nuxt'
+import { build } from './build'
 
 export async function generate () {
-  const { nuxt } = getContext()
-  const { Builder, Generator } = await loadNuxtPackage()
+  const ctx = getContext()
+  const { Generator } = await loadNuxtPackage()
 
-  const builder = new Builder(nuxt)
-  const generator = new Generator(nuxt, builder)
+  if (!ctx.builder) {
+    await build()
+  }
 
-  await generator.generate()
+  const generator = new Generator(ctx.nuxt, ctx.builder)
+
+  await generator.generate({ build: false })
 }


### PR DESCRIPTION
@ricardogobbosouza Inspired by your [comment](https://github.com/nuxt/test-utils/pull/150#issuecomment-879898834)

Generator could reuse builder if found in the context. And could add it to context if not found.

Or am I overthinking it and current use of `new Builder`, `new Generator` is more optimal?