### PR TITLE
fix: do not set `process.browser` globally

### DIFF
--- a/examples/app/app.vue
+++ b/examples/app/app.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
     <NuxtWelcome />
+    <MyComponent title="My title" />
   </div>
 </template>

--- a/examples/app/components/MyComponent.vue
+++ b/examples/app/components/MyComponent.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import type { MyComponentProps } from '~/types/component-props'
+
+defineProps<MyComponentProps>()
+</script>
+
+<template>
+  <div>
+    {{ title }}
+  </div>
+</template>

--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@nuxt/test-utils": "latest",
-    "happy-dom": "^12.10.3"
+    "happy-dom": "^12.10.3",
+    "typescript": "^5.2.2"
   }
 }

--- a/examples/app/types/component-props.ts
+++ b/examples/app/types/component-props.ts
@@ -1,0 +1,3 @@
+export interface MyComponentProps {
+  title: string
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
       happy-dom:
         specifier: ^12.10.3
         version: 12.10.3
+      typescript:
+        specifier: ^5.2.2
+        version: 5.2.2
 
   examples/app-jest:
     dependencies:

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,7 +65,10 @@ export async function getVitestConfigFromNuxt(
   overrides?: NuxtConfig
 ): Promise<InlineConfig & { test: VitestConfig }> {
   const { rootDir = process.cwd(), ..._overrides } = overrides || {}
-  if (!options) options = await startNuxtAndGetViteConfig(rootDir, _overrides)
+  if (!options) options = await startNuxtAndGetViteConfig(rootDir, {
+    test: true,
+    ..._overrides
+  })
   options.viteConfig.plugins = options.viteConfig.plugins || []
   options.viteConfig.plugins = options.viteConfig.plugins.filter(
     p => (p as any)?.name !== 'nuxt:import-protection'
@@ -81,9 +84,12 @@ export async function getVitestConfigFromNuxt(
     }
   }
 
-  return defu(
+  const resolvedConfig = defu(
     // overrides
     {
+      define: {
+        ['process.env.NODE_ENV']: 'process.env.NODE_ENV',
+      },
       test: {
         dir: process.cwd(),
         environmentOptions: {
@@ -114,9 +120,6 @@ export async function getVitestConfigFromNuxt(
       } satisfies VitestConfig
     },
     {
-      define: {
-        ['process.env.NODE_ENV']: 'process.env.NODE_ENV',
-      },
       server: { middlewareMode: false },
       plugins: [
         {
@@ -150,6 +153,10 @@ export async function getVitestConfigFromNuxt(
       } satisfies VitestConfig
     }
   ) as InlineConfig & { test: VitestConfig }
+
+  delete resolvedConfig.define!['process.browser']
+
+  return resolvedConfig
 }
 
 export function defineVitestConfig(config: InlineConfig & { test?: VitestConfig } = {}) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -154,6 +154,8 @@ export async function getVitestConfigFromNuxt(
     }
   ) as InlineConfig & { test: VitestConfig }
 
+  // TODO: fix this by separating nuxt/node vitest configs
+  // typescript currently checks this to determine if it can access the filesystem: https://github.com/microsoft/TypeScript/blob/d4fbc9b57d9aa7d02faac9b1e9bb7b37c687f6e9/src/compiler/core.ts#L2738-L2749
   delete resolvedConfig.define!['process.browser']
 
   return resolvedConfig


### PR DESCRIPTION
resolves https://github.com/nuxt/test-utils/issues/237

The issue here is that we are 'leaking' vitest config into the node context which runs e2e tests. Do you think there's a better way to avoid this, and just use this config for the nuxt environment @antfu?