### PR TITLE
fix!: load nuxt app within `setupFiles`

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,6 @@
     "@testing-library/vue": "8.0.1",
     "@types/estree": "1.0.5",
     "@types/jsdom": "21.1.6",
-    "@vitejs/plugin-vue": "4.5.1",
-    "@vitejs/plugin-vue-jsx": "3.1.0",
     "@vitest/ui": "0.33.0",
     "@vue/test-utils": "2.4.3",
     "changelogen": "0.5.5",
@@ -89,8 +87,6 @@
   "peerDependencies": {
     "@jest/globals": "^29.5.0",
     "@testing-library/vue": "^7.0.0 || ^8.0.1",
-    "@vitejs/plugin-vue": "*",
-    "@vitejs/plugin-vue-jsx": "*",
     "@vitest/ui": "0.33.0",
     "@vue/test-utils": "^2.4.2",
     "h3": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,12 +105,6 @@ importers:
       '@types/jsdom':
         specifier: 21.1.6
         version: 21.1.6
-      '@vitejs/plugin-vue':
-        specifier: 4.5.1
-        version: 4.5.1(vite@5.0.4)(vue@3.3.9)
-      '@vitejs/plugin-vue-jsx':
-        specifier: 3.1.0
-        version: 3.1.0(vite@5.0.4)(vue@3.3.9)
       '@vitest/ui':
         specifier: 0.33.0
         version: 0.33.0(vitest@0.33.0)

--- a/src/environments/vitest/index.ts
+++ b/src/environments/vitest/index.ts
@@ -30,6 +30,8 @@ export default <Environment>{
       jsdom: { url },
     }))
 
+    win.__NUXT_VITEST_ENVIRONMENT__ = true
+
     win.__NUXT__ = {
       serverRendered: false,
       config: {
@@ -137,14 +139,12 @@ export default <Environment>{
     registry.add(`${manifestOutputPath}/meta/test.json`)
     registry.add(`${manifestOutputPath}/meta/dev.json`)
 
-    await import('#app/entry').then(r => r.default())
-
     return {
       // called after all tests with this env have been run
       teardown() {
-        teardown()
         keys.forEach(key => delete global[key])
         originals.forEach((v, k) => (global[k] = v))
+        teardown()
       },
     }
   },

--- a/src/environments/vitest/types.ts
+++ b/src/environments/vitest/types.ts
@@ -4,6 +4,7 @@ export type NuxtBuiltinEnvironment = 'happy-dom' | 'jsdom'
 export interface NuxtWindow extends Window {
   __app: App
   __registry: Set<string>
+  __NUXT_VITEST_ENVIRONMENT__?: boolean
   __NUXT__: any
   $fetch: any
   fetch: any

--- a/src/module/plugins/entry.ts
+++ b/src/module/plugins/entry.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { createUnplugin } from "unplugin"
+
+const PLUGIN_NAME = 'nuxt:vitest:nuxt-root-stub'
+
+interface NuxtRootStubPluginOptions {
+  entry: string
+  rootStubPath: string
+}
+
+export const NuxtRootStubPlugin = createUnplugin((options: NuxtRootStubPluginOptions) => {
+  return {
+    name: PLUGIN_NAME,
+    enforce: 'pre',
+    vite: {
+      async resolveId(id) {
+        if (id.endsWith('nuxt-vitest-app-entry')) {
+          return id
+        }
+      },
+      async load(id) {
+        if (id.endsWith('nuxt-vitest-app-entry')) {
+          const entryContents = readFileSync(options.entry, 'utf-8')
+          return entryContents.replace('#build/root-component.mjs', options.rootStubPath)
+        }
+      }
+    },
+  }
+})

--- a/src/runtime/entry.ts
+++ b/src/runtime/entry.ts
@@ -1,0 +1,15 @@
+if (
+  typeof window !== 'undefined' &&
+  // @ts-expect-error undefined property
+  window.__NUXT_VITEST_ENVIRONMENT__
+) {
+  // @ts-expect-error alias to allow us to transform the entrypoint
+  await import('#app/nuxt-vitest-app-entry').then(r => r.default())
+  // We must manually call `page:finish` to snc route after navigation
+  // as there is no `<NuxtPage>` instantiated by default.
+  const nuxtApp = useNuxtApp()
+  await nuxtApp.callHook('page:finish')
+  useRouter().afterEach(() => nuxtApp.callHook('page:finish'))
+}
+
+export {}

--- a/src/runtime/nuxt-root.ts
+++ b/src/runtime/nuxt-root.ts
@@ -1,0 +1,30 @@
+import { Suspense, defineComponent, h, onErrorCaptured, provide } from 'vue'
+import { isNuxtError, useNuxtApp, useRoute } from '#imports'
+import { PageRouteSymbol } from '#app/components/injections'
+
+export default defineComponent({
+  setup (_options, { slots }) {
+    const nuxtApp = useNuxtApp()
+
+    // Inject default route (outside of pages) as active route
+    provide(PageRouteSymbol, useRoute())
+
+    const done = nuxtApp.deferHydration()
+
+    // vue:setup hook
+    const results = nuxtApp.hooks.callHookWith(hooks => hooks.map(hook => hook()), 'vue:setup')
+    if (import.meta.dev && results && results.some(i => i && 'then' in i)) {
+      console.error('[nuxt] Error in `vue:setup`. Callbacks must be synchronous.')
+    }
+
+    // error handling
+    onErrorCaptured((err, target, info) => {
+      nuxtApp.hooks.callHook('vue:error', err, target, info).catch(hookError => console.error('[nuxt] Error in `vue:error` hook', hookError))
+      if (isNuxtError(err) && (err.fatal || err.unhandled)) {
+        return false // suppress error from breaking render
+      }
+    })
+
+    return () => h(Suspense, { onResolve: done }, slots.default?.())
+  }
+})

--- a/test/unit/mock-transform.spec.ts
+++ b/test/unit/mock-transform.spec.ts
@@ -50,13 +50,15 @@ describe('mocking', () => {
       `)).toMatchInlineSnapshot(`
         "import {vi} from \\"vitest\\";
         vi.hoisted(() => { 
-                if(!global.__NUXT_VITEST_MOCKS){
+                if(!globalThis.__NUXT_VITEST_MOCKS){
                   vi.stubGlobal(\\"__NUXT_VITEST_MOCKS\\", {})
                 }
               });
         vi.mock(\\"bob\\", async (importOriginal) => {
-          const mocks = global.__NUXT_VITEST_MOCKS
-          if (!mocks[\\"bob\\"]) { mocks[\\"bob\\"] = { ...await importOriginal(\\"bob\\") } }
+          const mocks = globalThis.__NUXT_VITEST_MOCKS
+          if (!mocks[\\"bob\\"]) {
+            mocks[\\"bob\\"] = { ...await importOriginal(\\"bob\\") }
+          }
           mocks[\\"bob\\"][\\"useSomeExport\\"] = await (() => {
                   return () => 'mocked'
                 })();
@@ -100,7 +102,7 @@ describe('mocking', () => {
       `)).toMatchInlineSnapshot(`
         "import {vi} from \\"vitest\\";
         vi.hoisted(() => { 
-                if(!global.__NUXT_VITEST_MOCKS){
+                if(!globalThis.__NUXT_VITEST_MOCKS){
                   vi.stubGlobal(\\"__NUXT_VITEST_MOCKS\\", {})
                 }
               });


### PR DESCRIPTION
This moves the Nuxt environment setup into `setupFiles` which will provide a more consistent approach in future (https://github.com/danielroe/nuxt-vitest/pull/290#issuecomment-1744345443).

I've separated out this refactor from the move to Vitest 0.34+ as the approach is backwards-compatible.

resolves https://github.com/nuxt/test-utils/issues/573

cc: @sheremet-va