### PR TITLE
fix: use `buildDir` option

### DIFF
--- a/src/core/nuxt.ts
+++ b/src/core/nuxt.ts
@@ -43,7 +43,7 @@ export async function loadFixture () {
 
   if (!ctx.options.dev) {
     const randomId = Math.random().toString(36).slice(2, 8)
-    const buildDir = resolve(ctx.options.rootDir, '.nuxt', randomId)
+    const buildDir = ctx.options.buildDir || resolve(ctx.options.rootDir, '.nuxt', randomId)
     ctx.options.nuxtConfig = defu(ctx.options.nuxtConfig, {
       buildDir,
       nitro: {


### PR DESCRIPTION
The types for the `setup()` function provide a `buildDir` option, this isn't used.

```ts
const { resolve } = createResolver(import.meta.url)

await setup({
  rootDir: resolve('../fixtures/basic'),
  buildDir: resolve('./build'), // doesn't do anything
})
```