### PR TITLE
fix: teardown test build directories

### DIFF
--- a/src/core/nuxt.ts
+++ b/src/core/nuxt.ts
@@ -43,7 +43,7 @@ export async function loadFixture () {
 
   if (!ctx.options.dev) {
     const randomId = Math.random().toString(36).slice(2, 8)
-    const buildDir = resolve(ctx.options.rootDir, '.nuxt', randomId)
+    const buildDir = ctx.options.buildDir || resolve(ctx.options.rootDir, '.nuxt', randomId)
     ctx.options.nuxtConfig = defu(ctx.options.nuxtConfig, {
       buildDir,
       nitro: {

--- a/src/core/nuxt.ts
+++ b/src/core/nuxt.ts
@@ -65,8 +65,8 @@ export async function loadFixture () {
   // avoid creating / deleting build dirs that already exist - avoids misconfiguration deletes
   if (!existsSync(buildDir)) {
     await fsp.mkdir(buildDir, { recursive: true })
-    ctx.sideEffects = ctx.sideEffects || []
-    ctx.sideEffects.push(() => fsp.rm(buildDir, { recursive: true, force: true }))
+    ctx.teardown = ctx.teardown || []
+    ctx.teardown.push(() => fsp.rm(buildDir, { recursive: true, force: true }))
   }
 }
 

--- a/src/core/nuxt.ts
+++ b/src/core/nuxt.ts
@@ -61,10 +61,9 @@ export async function loadFixture () {
     configFile: ctx.options.configFile
   })
 
-  // avoid deleting build dirs we didn't create - avoids misconfiguration deletes
+  // avoid creating / deleting build dirs that already exist - avoids misconfiguration deletes
   if (!existsSync(ctx.nuxt.options.buildDir)) {
     await fsp.mkdir(ctx.nuxt.options.buildDir, { recursive: true })
-    // clean up after ourselves,
     ctx.sideEffects = ctx.sideEffects || []
     ctx.sideEffects.push(() => fsp.rm(ctx.nuxt.options.buildDir, { recursive: true, force: true }))
   }

--- a/src/core/nuxt.ts
+++ b/src/core/nuxt.ts
@@ -61,11 +61,12 @@ export async function loadFixture () {
     configFile: ctx.options.configFile
   })
 
+  const buildDir = ctx.nuxt.options.buildDir
   // avoid creating / deleting build dirs that already exist - avoids misconfiguration deletes
-  if (!existsSync(ctx.nuxt.options.buildDir)) {
-    await fsp.mkdir(ctx.nuxt.options.buildDir, { recursive: true })
+  if (!existsSync(buildDir)) {
+    await fsp.mkdir(buildDir, { recursive: true })
     ctx.sideEffects = ctx.sideEffects || []
-    ctx.sideEffects.push(() => fsp.rm(ctx.nuxt.options.buildDir, { recursive: true, force: true }))
+    ctx.sideEffects.push(() => fsp.rm(buildDir, { recursive: true, force: true }))
   }
 }
 

--- a/src/core/nuxt.ts
+++ b/src/core/nuxt.ts
@@ -43,7 +43,7 @@ export async function loadFixture () {
 
   if (!ctx.options.dev) {
     const randomId = Math.random().toString(36).slice(2, 8)
-    const buildDir = ctx.options.buildDir || resolve(ctx.options.rootDir, '.nuxt', randomId)
+    const buildDir = ctx.options.buildDir || resolve(ctx.options.rootDir, '.nuxt', 'test', randomId)
     ctx.options.nuxtConfig = defu(ctx.options.nuxtConfig, {
       buildDir,
       nitro: {
@@ -61,7 +61,13 @@ export async function loadFixture () {
     configFile: ctx.options.configFile
   })
 
-  await fsp.mkdir(ctx.nuxt.options.buildDir, { recursive: true })
+  // avoid deleting build dirs we didn't create - avoids misconfiguration deletes
+  if (!existsSync(ctx.nuxt.options.buildDir)) {
+    await fsp.mkdir(ctx.nuxt.options.buildDir, { recursive: true })
+    // clean up after ourselves,
+    ctx.sideEffects = ctx.sideEffects || []
+    ctx.sideEffects.push(() => fsp.rm(ctx.nuxt.options.buildDir, { recursive: true, force: true }))
+  }
 }
 
 export async function buildFixture () {

--- a/src/core/setup/index.ts
+++ b/src/core/setup/index.ts
@@ -34,6 +34,8 @@ export function createTest (options: Partial<TestOptions>): TestHooks {
     if (ctx.browser) {
       await ctx.browser.close()
     }
+    // clear side effects
+    await Promise.all((ctx.sideEffects || []).map(fn => fn()))
   }
 
   const setup = async () => {

--- a/src/core/setup/index.ts
+++ b/src/core/setup/index.ts
@@ -35,7 +35,7 @@ export function createTest (options: Partial<TestOptions>): TestHooks {
       await ctx.browser.close()
     }
     // clear side effects
-    await Promise.all((ctx.sideEffects || []).map(fn => fn()))
+    await Promise.all((ctx.teardown || []).map(fn => fn()))
   }
 
   const setup = async () => {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -33,7 +33,11 @@ export interface TestContext {
   url?: string
   serverProcess?: ExecaChildProcess
   mockFn?: Function
-  sideEffects?: (() => void)[]
+  /**
+   * Functions to run on the vitest `afterAll` hook.
+   * Useful for removing anything created during the test.
+   */
+  teardown?: (() => void)[]
 }
 
 export interface TestHooks {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -33,6 +33,7 @@ export interface TestContext {
   url?: string
   serverProcess?: ExecaChildProcess
   mockFn?: Function
+  sideEffects?: (() => void)[]
 }
 
 export interface TestHooks {


### PR DESCRIPTION
Review this first: https://github.com/nuxt/test-utils/pull/596

## Issue

Test build dirs will just keep stacking up. There is no logic in place to remove them.

This isn't ideal, especially when your IDE tries to index these files (even though they're ignored - phpstorm :angry:)

![image](https://github.com/nuxt/test-utils/assets/5326365/d6733143-9632-485e-9fd5-3f6bb5c8909b)

## Solution

This PR includes a few important fixes:
- group test builds in a `test` directory so they can easily be cleaned up manually, this may be needed if a test fails/is force quit
- mark the build directory that's created as a side effect and clean it up once the tests are finished