### PR TITLE
test: add tests for events emitted from `defineModel`

### DIFF
--- a/examples/app-vitest-full/components/WrapperTests.vue
+++ b/examples/app-vitest-full/components/WrapperTests.vue
@@ -23,6 +23,9 @@ defineExpose({
     >
       Click me!
     </button>
-    <button id="changeModelValue" @click="modelValue = true" />
+    <button
+      id="changeModelValue"
+      @click="modelValue = true"
+    />
   </div>
 </template>

--- a/examples/app-vitest-full/components/WrapperTests.vue
+++ b/examples/app-vitest-full/components/WrapperTests.vue
@@ -4,19 +4,25 @@ const emit = defineEmits<{
   otherEvent: []
 }>()
 
-function testExpose () {
+function testExpose() {
   return 'expose was successful'
 }
 
+const modelValue = defineModel({ default: false })
+
 defineExpose({
-  testExpose
+  testExpose,
 })
 </script>
 
 <template>
   <div>
-    <button @click="emit('customEvent', 'foo'); $emit('otherEvent')">
+    <button
+      id="emitCustomEvent"
+      @click="emit('customEvent', 'foo'); $emit('otherEvent')"
+    >
       Click me!
     </button>
+    <button id="changeModelValue" @click="modelValue = true" />
   </div>
 </template>

--- a/examples/app-vitest-full/components/WrapperTests.vue
+++ b/examples/app-vitest-full/components/WrapperTests.vue
@@ -4,14 +4,14 @@ const emit = defineEmits<{
   otherEvent: []
 }>()
 
-function testExpose() {
+function testExpose () {
   return 'expose was successful'
 }
 
 const modelValue = defineModel({ default: false })
 
 defineExpose({
-  testExpose,
+  testExpose
 })
 </script>
 

--- a/examples/app-vitest-full/nuxt.config.ts
+++ b/examples/app-vitest-full/nuxt.config.ts
@@ -2,6 +2,13 @@
 export default defineNuxtConfig({
   devtools: { enabled: true },
   modules: ['@nuxt/test-utils/module', '~/modules/custom'],
+  vite: {
+    vue: {
+      script: {
+        defineModel: true,
+      },
+    },
+  },
   vitest: {
     startOnBoot: true,
     logToConsole: true,

--- a/examples/app-vitest-full/tests/nuxt/index.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/index.spec.ts
@@ -10,6 +10,8 @@ import FetchComponent from '~/components/FetchComponent.vue'
 import OptionsComponent from '~/components/OptionsComponent.vue'
 import WrapperTests from '~/components/WrapperTests.vue'
 
+import { mount } from '@vue/test-utils'
+
 describe('client-side nuxt features', () => {
   it('can use core nuxt composables within test file', () => {
     expect(useAppConfig().hey).toMatchInlineSnapshot('false')
@@ -100,7 +102,7 @@ describe('test utils', () => {
 
   it('can receive emitted events from components mounted within nuxt suspense', async () => {
     const component = await mountSuspended(WrapperTests)
-    component.find('button').trigger('click')
+    component.find('button#emitCustomEvent').trigger('click')
     expect(component.emitted()).toMatchInlineSnapshot(`
       {
         "customEvent": [
@@ -126,6 +128,19 @@ describe('test utils', () => {
       id: 1,
     })
     await server.close()
+  })
+  
+  // This test works (you can delete it later)
+  it('can receive emitted events from components using defineModel', () => {
+    const component = mount(WrapperTests)
+    component.find('button#changeModelValue').trigger('click')
+    expect(component.emitted()).toHaveProperty('update:modelValue')
+  })
+
+  it('can receive emitted events from components mounted within nuxt suspense using defineModel', async () => {
+    const component = await mountSuspended(WrapperTests)
+    component.find('button#changeModelValue').trigger('click')
+    expect(component.emitted()).toHaveProperty('update:modelValue')
   })
 
   it('can mock fetch requests', async () => {

--- a/examples/app-vitest-full/tests/nuxt/index.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/index.spec.ts
@@ -129,7 +129,7 @@ describe('test utils', () => {
     })
     await server.close()
   })
-  
+
   // This test works (you can delete it later)
   it('can receive emitted events from components using defineModel', () => {
     const component = mount(WrapperTests)
@@ -137,7 +137,8 @@ describe('test utils', () => {
     expect(component.emitted()).toHaveProperty('update:modelValue')
   })
 
-  it('can receive emitted events from components mounted within nuxt suspense using defineModel', async () => {
+  // TODO: fix this failing test
+  it.todo('can receive emitted events from components mounted within nuxt suspense using defineModel', async () => {
     const component = await mountSuspended(WrapperTests)
     component.find('button#changeModelValue').trigger('click')
     expect(component.emitted()).toHaveProperty('update:modelValue')


### PR DESCRIPTION
closes https://github.com/nuxt/nuxt-vitest/pull/193
linked to https://github.com/nuxt/test-utils/issues/572