### PR TITLE
fix(vitest-environment): normalise `setupFiles` to array before merge

### DIFF
--- a/examples/app-vitest-full/vitest.config.ts
+++ b/examples/app-vitest-full/vitest.config.ts
@@ -18,7 +18,7 @@ export default defineVitestConfig({
         },
       },
     },
-    setupFiles: ['./tests/setup/mocks.ts'],
+    setupFiles: './tests/setup/mocks.ts',
     globals: true,
   },
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -175,6 +175,10 @@ export function defineVitestConfig(config: InlineConfig & { test?: VitestConfig 
     const overrides = config.test?.environmentOptions?.nuxt?.overrides || {}
     overrides.rootDir = config.test?.environmentOptions?.nuxt?.rootDir
 
+    if (config.test.setupFiles && !Array.isArray(config.test.setupFiles)) {
+      config.test.setupFiles = [config.test.setupFiles].filter(Boolean) as string[]
+    }
+
     return defu(
       config,
       await getVitestConfigFromNuxt(undefined, structuredClone(overrides)),

--- a/src/config.ts
+++ b/src/config.ts
@@ -175,7 +175,7 @@ export function defineVitestConfig(config: InlineConfig & { test?: VitestConfig 
     const overrides = config.test?.environmentOptions?.nuxt?.overrides || {}
     overrides.rootDir = config.test?.environmentOptions?.nuxt?.rootDir
 
-    if (config.test.setupFiles && !Array.isArray(config.test.setupFiles)) {
+    if (config.test?.setupFiles && !Array.isArray(config.test.setupFiles)) {
       config.test.setupFiles = [config.test.setupFiles].filter(Boolean) as string[]
     }
 


### PR DESCRIPTION
resolves #647