### PR TITLE
fix(runtime-utils): RouterLink - use the correct href when props.to is object

### DIFF
--- a/examples/app-vitest-full/components/LinkTests.vue
+++ b/examples/app-vitest-full/components/LinkTests.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <NuxtLink to="/test">
+      Link with string to prop
+    </NuxtLink>
+    <NuxtLink :to="{ path: '/test'}">
+      Link with object to prop
+    </NuxtLink>
+  </div>
+</template>

--- a/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
@@ -5,6 +5,7 @@ import { mountSuspended } from '@nuxt/test-utils/runtime'
 import App from '~/app.vue'
 import OptionsComponent from '~/components/OptionsComponent.vue'
 import WrapperTests from '~/components/WrapperTests.vue'
+import LinkTests from '~/components/LinkTests.vue'
 
 import type { VueWrapper} from '@vue/test-utils';
 import { mount } from '@vue/test-utils'
@@ -148,4 +149,10 @@ describe.each(Object.entries(formats))(`%s`, (name, component) => {
 </div>
     `.trim())
   })
+})
+
+it('renders links correctly', async () => {
+  const component = await mountSuspended(LinkTests)
+
+  expect(component.html()).toMatchInlineSnapshot(`"<div><a href="/test"> Link with string to prop </a><a href="/test"> Link with object to prop </a></div>"`)
 })

--- a/examples/app-vitest-full/tests/nuxt/render-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/render-suspended.spec.ts
@@ -5,6 +5,7 @@ import { cleanup, fireEvent, screen } from '@testing-library/vue'
 import App from '~/app.vue'
 import OptionsComponent from '~/components/OptionsComponent.vue'
 import WrapperTests from '~/components/WrapperTests.vue'
+import LinkTests from '~/components/LinkTests.vue'
 
 describe('renderSuspended', () => {
   afterEach(() => {
@@ -90,5 +91,12 @@ describe('renderSuspended', () => {
         ],
       }
     `)
+  })
+
+  it('renders links correctly', async () => {
+    await renderSuspended(LinkTests)
+
+    expect(screen.getByRole('link', { name: 'Link with string to prop'})).toHaveProperty('href', 'http://localhost:3000/test')
+    expect(screen.getByRole('link', { name: 'Link with object to prop'})).toHaveProperty('href', 'http://localhost:3000/test')
   })
 })

--- a/src/runtime-utils/components/RouterLink.ts
+++ b/src/runtime-utils/components/RouterLink.ts
@@ -3,7 +3,10 @@ import { defineComponent, h, useRouter } from '#imports'
 export const RouterLink = defineComponent({
   functional: true,
   props: {
-    to: [String, Object],
+    to: {
+      type: [String, Object],
+      required: true
+    },
     custom: Boolean,
     replace: Boolean,
     // Not implemented
@@ -14,13 +17,14 @@ export const RouterLink = defineComponent({
   setup: (props, { slots }) => {
     const navigate = () => {}
     return () => {
-      const route = props.to ? useRouter().resolve(props.to) : {}
+      const route = useRouter().resolve(props.to)
+
       return props.custom
-        ? slots.default?.({ href: props.to, navigate, route })
+        ? slots.default?.({ href: route.href, navigate, route })
         : h(
             'a',
             {
-              href: props.to,
+              href: route.href,
               onClick: (e: MouseEvent) => {
                 e.preventDefault()
                 return navigate()


### PR DESCRIPTION
## What
* Update RouterLink to make the `to` prop required (it's required in the actual RouterLink component https://github.com/vuejs/vue-router/blob/0395bd83feb79b3cba399e68f991885c986f70ec/src/components/link.js#L23)
* Get the href from the resolved route, rather than `props.to`

## Why
* Fixes https://github.com/nuxt/test-utils/issues/686

