### PR TITLE
fix: add `playwright.d.ts` into `files`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "e2e.d.ts",
     "experimental.d.ts",
     "module.d.ts",
+    "playwright.d.ts",
     "runtime.d.ts",
     "vitest-environment.d.ts"
   ],


### PR DESCRIPTION
The `playwright.d.ts` is provided but not included in the `files`.
So, we would like to include it in `files`.