### PR TITLE
feat(runtime-utils): expose setup context from `renderSuspended` result

### DIFF
--- a/examples/app-vitest-full/tests/nuxt/render-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/render-suspended.spec.ts
@@ -1,11 +1,26 @@
 import { afterEach, describe, expect, it } from 'vitest'
+
 import { renderSuspended } from '@nuxt/test-utils/runtime'
-import { cleanup, fireEvent, screen } from '@testing-library/vue'
+import { cleanup, fireEvent, screen, render } from '@testing-library/vue'
 
 import App from '~/app.vue'
 import OptionsComponent from '~/components/OptionsComponent.vue'
 import WrapperTests from '~/components/WrapperTests.vue'
 import LinkTests from '~/components/LinkTests.vue'
+
+import ExportDefaultComponent from '~/components/ExportDefaultComponent.vue'
+import ExportDefineComponent from '~/components/ExportDefineComponent.vue'
+import ExportDefaultWithRenderComponent from '~/components/ExportDefaultWithRenderComponent.vue'
+import ExportDefaultReturnsRenderComponent from '~/components/ExportDefaultReturnsRenderComponent.vue'
+
+import { BoundAttrs } from '#components'
+
+const formats = {
+  ExportDefaultComponent,
+  ExportDefineComponent,
+  ExportDefaultWithRenderComponent,
+  ExportDefaultReturnsRenderComponent,
+}
 
 describe('renderSuspended', () => {
   afterEach(() => {
@@ -29,6 +44,13 @@ describe('renderSuspended', () => {
     `)
   })
 
+  it('should handle passing setup state and props to template', async () => {
+    const wrappedComponent = await renderSuspended(BoundAttrs)
+    const component = render(BoundAttrs)
+
+    expect(`<div id="test-wrapper">${component.html()}</div>`).toEqual(wrappedComponent.html())
+  })
+
   it('should render default props within nuxt suspense', async () => {
     await renderSuspended(OptionsComponent)
     expect(screen.getByRole('heading', { level: 2 })).toMatchInlineSnapshot(
@@ -43,20 +65,20 @@ describe('renderSuspended', () => {
   it('should render passed props within nuxt suspense', async () => {
     await renderSuspended(OptionsComponent, {
       props: {
-        title: 'title from mount suspense props',
+        title: 'title from render suspense props',
       },
     })
     expect(screen.getByRole('heading', { level: 2 })).toMatchInlineSnapshot(
       `
       <h2>
-        title from mount suspense props
+        title from render suspense props
       </h2>
     `,
     )
   })
 
   it('can pass slots to rendered components within nuxt suspense', async () => {
-    const text = 'slot from mount suspense'
+    const text = 'slot from render suspense'
     await renderSuspended(OptionsComponent, {
       slots: {
         default: () => text,
@@ -92,11 +114,31 @@ describe('renderSuspended', () => {
       }
     `)
   })
+})
 
-  it('renders links correctly', async () => {
-    await renderSuspended(LinkTests)
+describe.each(Object.entries(formats))(`%s`, (name, component) => {
+  it('mounts with props', async () => {
+    const wrapper = await renderSuspended(component, {
+      props: {
+        myProp: 'Hello nuxt-vitest',
+      },
+    })
 
-    expect(screen.getByRole('link', { name: 'Link with string to prop' })).toHaveProperty('href', 'http://localhost:3000/test')
-    expect(screen.getByRole('link', { name: 'Link with object to prop' })).toHaveProperty('href', 'http://localhost:3000/test')
+    expect(wrapper.html()).toEqual(`
+<div id="test-wrapper">
+  <div>
+    <h1>${name}</h1><pre>Hello nuxt-vitest</pre><pre>XHello nuxt-vitest</pre>
+  </div>
+</div>
+    `.trim())
   })
+})
+
+it('renders links correctly', async () => {
+  const component = await renderSuspended(LinkTests)
+
+  expect(component.html()).toMatchInlineSnapshot(`
+  "<div id="test-wrapper">
+    <div><a href="/test"> Link with string to prop </a><a href="/test"> Link with object to prop </a></div>
+  </div>"`)
 })

--- a/src/runtime-utils/render.ts
+++ b/src/runtime-utils/render.ts
@@ -1,4 +1,4 @@
-import { Suspense, effectScope, h, nextTick } from 'vue'
+import { Suspense, effectScope, h, nextTick, isReadonly, unref } from 'vue'
 import type { DefineComponent, SetupContext } from 'vue'
 import type { RenderOptions as TestingLibraryRenderOptions } from '@testing-library/vue'
 import { defu } from 'defu'
@@ -16,6 +16,8 @@ export type RenderOptions<C = unknown> = TestingLibraryRenderOptions<C> & {
 
 export const WRAPPER_EL_ID = 'test-wrapper'
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SetupState = Record<string, any>
 /**
  * `renderSuspended` allows you to mount any vue component within the Nuxt environment, allowing async setup and access to injections from your Nuxt plugins.
  *
@@ -65,7 +67,10 @@ export async function renderSuspended<T>(
   const vueApp = tryUseNuxtApp()?.vueApp
     // @ts-expect-error untyped global __unctx__
     || globalThis.__unctx__.get('nuxt-app').tryUse().vueApp
-  const { render, setup } = component as DefineComponent<Record<string, unknown>, Record <string, unknown>>
+  const { render, setup } = component as DefineComponent<Record<string, unknown>, Record<string, unknown>>
+
+  let setupContext: SetupContext
+  let setupState: SetupState
 
   // cleanup previously mounted test wrappers
   for (const fn of window.__cleanup || []) {
@@ -73,9 +78,20 @@ export async function renderSuspended<T>(
   }
   document.querySelector(`#${WRAPPER_EL_ID}`)?.remove()
 
-  let setupContext: SetupContext
+  let passedProps: Record<string, unknown>
+  const wrappedSetup = async (
+    props: Record<string, unknown>,
+    setupContext: SetupContext,
+  ) => {
+    passedProps = props
+    if (setup) {
+      const result = await setup(props, setupContext)
+      setupState = result && typeof result === 'object' ? result : {}
+      return result
+    }
+  }
 
-  return new Promise<ReturnType<typeof renderFromTestingLibrary>>((resolve) => {
+  return new Promise<ReturnType<typeof renderFromTestingLibrary> & { setupState: SetupState }>((resolve) => {
     const utils = renderFromTestingLibrary(
       {
         setup: (props: Record<string, unknown>, ctx: SetupContext) => {
@@ -90,10 +106,10 @@ export async function renderSuspended<T>(
 
           return scope.run(() => NuxtRoot.setup(props, {
             ...ctx,
-            expose: () => {},
+            expose: () => ({}),
           }))
         },
-        render: (renderContext: unknown) =>
+        render: (renderContext: Record<string, unknown>) =>
           // See discussions in https://github.com/testing-library/vue-testing-library/issues/230
           // we add this additional root element because otherwise testing-library breaks
           // because there's no root element while Suspense is resolving
@@ -102,23 +118,40 @@ export async function renderSuspended<T>(
             { id: WRAPPER_EL_ID },
             h(
               Suspense,
-              { onResolve: () => nextTick().then(() => resolve(utils)) },
+              {
+                onResolve: () =>
+                  nextTick().then(() => {
+                    (utils as unknown as AugmentedVueInstance).setupState = setupState
+                    resolve(utils as ReturnType<typeof renderFromTestingLibrary> & { setupState: SetupState })
+                  }),
+              },
               {
                 default: () =>
                   h({
+                    name: 'RenderHelper',
                     async setup() {
                       const router = useRouter()
                       await router.replace(route)
 
                       // Proxy top-level setup/render context so test wrapper resolves child component
                       const clonedComponent = {
+                        name: 'RenderSuspendedComponent',
                         ...component,
                         render: render
-                          ? (_ctx: unknown, ...args: unknown[]) => render(renderContext, ...args)
+                          ? function (this: unknown, _ctx: Record<string, unknown>, ...args: unknown[]) {
+                            for (const key in setupState || {}) {
+                              renderContext[key] = isReadonly(setupState[key]) ? unref(setupState[key]) : setupState[key]
+                            }
+                            for (const key in props || {}) {
+                              renderContext[key] = _ctx[key]
+                            }
+                            for (const key in passedProps || {}) {
+                              renderContext[key] = passedProps[key]
+                            }
+                            return render.call(this, renderContext, ...args)
+                          }
                           : undefined,
-                        setup: setup
-                          ? (props: Record<string, unknown>) => setup(props, setupContext)
-                          : undefined,
+                        setup: setup ? (props: Record<string, unknown>) => wrappedSetup(props, setupContext) : undefined,
                       }
 
                       return () => h(clonedComponent, { ...(props && typeof props === 'object' ? props : {}), ...attrs }, slots)
@@ -146,4 +179,8 @@ declare global {
   interface Window {
     __cleanup?: Array<() => void>
   }
+}
+
+interface AugmentedVueInstance {
+  setupState?: SetupState
 }


### PR DESCRIPTION
After a lot of internal testing in my private project and seeing some similar opened issues about the context returned by setup was not being accessible in the component, I saw that there was a difference in the way how `mountSuspended` and `renderSuspended` were defined.

In `mountSuspended` things always worked, looking at the difference between the two I ended up arriving at the PR https://github.com/danielroe/nuxt-vitest/pull/391 which introduced a fix for this, but only on the mountSuspended function

It would be cool at some point to unify what is possible in these two functions. There is a lot of duplicated logic between  both

Fix: https://github.com/nuxt/test-utils/issues/722