### PR TITLE
fix(runtime-utils): `setProps` can replace array prop

### DIFF
--- a/examples/app-vitest-full/components/ExportDefaultComponent.vue
+++ b/examples/app-vitest-full/components/ExportDefaultComponent.vue
@@ -3,6 +3,8 @@
     <h1>ExportDefaultComponent</h1>
     <pre>{{ myProp }}</pre>
     <pre>{{ setupMyProp }}</pre>
+    <span v-for="item in myArrayProp" :key="item">{{ item }}
+    </span>
   </div>
 </template>
 
@@ -21,6 +23,10 @@ export default {
     myProp: {
       type: String,
       required: true,
+    },
+    myArrayProp: {
+      type: Array as PropType<string[]>,
+      default: () => ([]),
     },
   },
   setup(props) {

--- a/examples/app-vitest-full/components/ExportDefaultComponent.vue
+++ b/examples/app-vitest-full/components/ExportDefaultComponent.vue
@@ -3,7 +3,10 @@
     <h1>ExportDefaultComponent</h1>
     <pre>{{ myProp }}</pre>
     <pre>{{ setupMyProp }}</pre>
-    <span v-for="item in myArrayProp" :key="item">{{ item }}
+    <span
+      v-for="item in myArrayProp"
+      :key="item"
+    >{{ item }}
     </span>
   </div>
 </template>

--- a/examples/app-vitest-full/components/ExportDefaultReturnsRenderComponent.vue
+++ b/examples/app-vitest-full/components/ExportDefaultReturnsRenderComponent.vue
@@ -5,6 +5,10 @@ export default {
       type: String,
       required: true,
     },
+    myArrayProp: {
+      type: Array as PropType<string[]>,
+      default: () => ([]),
+    },
   },
   setup(props) {
     const pre = 'X' + props.myProp
@@ -12,6 +16,7 @@ export default {
       h('h1', 'ExportDefaultReturnsRenderComponent'),
       h('pre', props.myProp),
       h('pre', pre),
+      props.myArrayProp.map(item => h('span', item)),
     ])
   },
 }

--- a/examples/app-vitest-full/components/ExportDefaultWithRenderComponent.vue
+++ b/examples/app-vitest-full/components/ExportDefaultWithRenderComponent.vue
@@ -5,6 +5,10 @@ export default {
       type: String,
       required: true,
     },
+    myArrayProp: {
+      type: Array as PropType<string[]>,
+      default: () => ([]),
+    },
   },
   setup(props) {
     return {
@@ -16,6 +20,7 @@ export default {
       h('h1', 'ExportDefaultWithRenderComponent'),
       h('pre', this.myProp),
       h('pre', this.setupMyProp),
+      this.myArrayProp.map(item => h('span', item)),
     ])
   },
 }

--- a/examples/app-vitest-full/components/ExportDefineComponent.vue
+++ b/examples/app-vitest-full/components/ExportDefineComponent.vue
@@ -3,7 +3,10 @@
     <h1>ExportDefineComponent</h1>
     <pre>{{ myProp }}</pre>
     <pre>{{ setupMyProp }}</pre>
-    <span v-for="item in myArrayProp" :key="item">{{ item }}</span>
+    <span
+      v-for="item in myArrayProp"
+      :key="item"
+    >{{ item }}</span>
   </div>
 </template>
 

--- a/examples/app-vitest-full/components/ExportDefineComponent.vue
+++ b/examples/app-vitest-full/components/ExportDefineComponent.vue
@@ -3,6 +3,7 @@
     <h1>ExportDefineComponent</h1>
     <pre>{{ myProp }}</pre>
     <pre>{{ setupMyProp }}</pre>
+    <span v-for="item in myArrayProp" :key="item">{{ item }}</span>
   </div>
 </template>
 
@@ -21,6 +22,10 @@ export default defineComponent({
     myProp: {
       type: String,
       required: true,
+    },
+    myArrayProp: {
+      type: Array as PropType<string[]>,
+      default: () => ([]),
     },
   },
   setup(props) {

--- a/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
@@ -126,6 +126,7 @@ describe.each(Object.entries(formats))(`%s`, (name, component) => {
     wrapper = await mountSuspended(component, {
       props: {
         myProp: 'Hello nuxt-vitest',
+        myArrayProp: ['hello', 'nuxt', 'vitest'],
       },
     })
   })
@@ -133,7 +134,7 @@ describe.each(Object.entries(formats))(`%s`, (name, component) => {
   it('mounts with props', () => {
     expect(wrapper.html()).toEqual(`
 <div>
-  <h1>${name}</h1><pre>Hello nuxt-vitest</pre><pre>XHello nuxt-vitest</pre>
+  <h1>${name}</h1><pre>Hello nuxt-vitest</pre><pre>XHello nuxt-vitest</pre><span>hello</span><span>nuxt</span><span>vitest</span>
 </div>
     `.trim())
   })
@@ -144,7 +145,19 @@ describe.each(Object.entries(formats))(`%s`, (name, component) => {
     })
     expect(wrapper.html()).toEqual(`
 <div>
-  <h1>${name}</h1><pre>updated title</pre><pre>XHello nuxt-vitest</pre>
+  <h1>${name}</h1><pre>updated title</pre><pre>XHello nuxt-vitest</pre><span>hello</span><span>nuxt</span><span>vitest</span>
+</div>
+    `.trim())
+  })
+
+  it('can be updated array with setProps', async () => {
+    await wrapper.setProps({
+      myProp: 'updated title',
+      myArrayProp: ['updated', 'prop'],
+    })
+    expect(wrapper.html()).toEqual(`
+<div>
+  <h1>${name}</h1><pre>updated title</pre><pre>XHello nuxt-vitest</pre><span>updated</span><span>prop</span>
 </div>
     `.trim())
   })

--- a/src/runtime-utils/mount.ts
+++ b/src/runtime-utils/mount.ts
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils'
 import type { ComponentMountingOptions } from '@vue/test-utils'
 import { Suspense, h, isReadonly, nextTick, reactive, unref } from 'vue'
 import type { DefineComponent, SetupContext } from 'vue'
-import { defu } from 'defu'
+import { defu, createDefu } from 'defu'
 import type { RouteLocationRaw } from 'vue-router'
 
 import { RouterLink } from './components/RouterLink'
@@ -134,7 +134,7 @@ export async function mountSuspended<T>(
                         setup: setup ? (props: Record<string, unknown>) => wrappedSetup(props, setupContext) : undefined,
                       }
 
-                      return () => h(clonedComponent, { ...defu(setProps, props) as typeof props, ...attrs }, slots)
+                      return () => h(clonedComponent, { ...defuReplaceArray(setProps, props) as typeof props, ...attrs }, slots)
                     },
                   }),
               },
@@ -167,3 +167,10 @@ interface AugmentedVueInstance {
   setupState?: Record<string, unknown>
   __setProps?: (props: Record<string, unknown>) => void
 }
+
+const defuReplaceArray = createDefu((obj, key, value) => {
+  if (Array.isArray(obj[key])) {
+    obj[key] = value
+    return true
+  }
+})


### PR DESCRIPTION
Use custom merge function via `createDefu` at `setProps()` to replace prop that has array type.
Because `defu()` concats array instead of overwrite in default behavior. ([Link](https://github.com/unjs/defu?tab=readme-ov-file#remarks)) 
> Will concat array values (if default property is defined)

Fix: #876 
