### PR TITLE
feat(playwright): reuse existing server

### DIFF
--- a/examples/app-playwright/playwright.config.ts
+++ b/examples/app-playwright/playwright.config.ts
@@ -13,7 +13,7 @@ const devicesToTest = [
   // Test against branded browsers.
   // { ...devices['Desktop Edge'], channel: 'msedge' },
   // { ...devices['Desktop Chrome'], channel: 'chrome' },
-] satisfies Array<string | typeof devices[string]>
+] satisfies Array<string | (typeof devices)[string]>
 
 /* See https://playwright.dev/docs/test-configuration. */
 export default defineConfig<ConfigOptions>({
@@ -34,8 +34,12 @@ export default defineConfig<ConfigOptions>({
     trace: 'on-first-retry',
     /* Nuxt configuration options */
     nuxt: {
+      /* Reuse a server if it's already running. Useful when developing tests. */
+      reuseExistingServer: process.env.CI ? false : true,
       rootDir: fileURLToPath(new URL('.', import.meta.url)),
     },
   },
-  projects: devicesToTest.map(p => typeof p === 'string' ? ({ name: p, use: devices[p] }) : p),
+  projects: devicesToTest.map(p =>
+    typeof p === 'string' ? { name: p, use: devices[p] } : p,
+  ),
 })

--- a/src/core/setup/index.ts
+++ b/src/core/setup/index.ts
@@ -1,6 +1,6 @@
 import { createTestContext, setTestContext } from '../context'
 import { buildFixture, loadFixture } from '../nuxt'
-import { startServer, stopServer } from '../server'
+import { reuseExistingServer, startServer, stopServer } from '../server'
 import { createBrowser } from '../browser'
 import type { TestHooks, TestOptions } from '../types'
 import setupCucumber from './cucumber'
@@ -41,20 +41,24 @@ export function createTest(options: Partial<TestOptions>): TestHooks {
   }
 
   const setup = async () => {
+    if (ctx.options.reuseExistingServer) {
+      await reuseExistingServer()
+    }
+
     if (ctx.options.fixture) {
       await loadFixture()
     }
 
-    if (ctx.options.build) {
+    if (ctx.options.build && !ctx.options.reuseExistingServer) {
       await buildFixture()
     }
 
-    if (ctx.options.server) {
+    if (ctx.options.server && !ctx.options.reuseExistingServer) {
       await startServer()
     }
 
     if (ctx.options.waitFor) {
-      await (new Promise(resolve => setTimeout(resolve, ctx.options.waitFor)))
+      await new Promise(resolve => setTimeout(resolve, ctx.options.waitFor))
     }
 
     if (ctx.options.browser) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -11,6 +11,7 @@ export interface TestOptions {
   rootDir: string
   buildDir: string
   nuxtConfig: NuxtConfig
+  reuseExistingServer?: boolean
   build: boolean
   dev: boolean
   setupTimeout: number
@@ -23,6 +24,7 @@ export interface TestOptions {
     launch?: LaunchOptions
   }
   server: boolean
+  host?: string
   port?: number
 }
 


### PR DESCRIPTION
Hello 👋,

I was trying this module to write tests cause I really think tests are important.

But, in development, this module, e2e with Playwright, is slow. So slow that it creates too much friction to write tests and I think a lot of people will give up on writing tests because of that.

In the meantime, I use Playwright at work for e2e testing on an Angular app and it's fast. It's faster than unit tests with Jest and it's possible make test-first development with it.

After deep diving into the module, I found that for each test and each run a new app is built and started. This is the main reason for the slowness. While I understand this behavior on a CI pipeline, I don't think it's necessary on development. This is too much overhead for a little (or no) gain.

So I added a new option (similar to the existing one in Playwright, https://playwright.dev/docs/test-webserver#configuring-a-web-server) to reuse a dev server for all tests. This speeds up the tests a lot and makes it possible to use test-first development with Playwright.

_While writing this, I realized that it could be possible to reuse the existing options instead of add a new one in the `use.nuxt` object. I'll try to do that in this PR._
