### PR TITLE
feat(e2e): allow overwriting env variables in `setup`

### DIFF
--- a/src/core/setup/index.ts
+++ b/src/core/setup/index.ts
@@ -50,7 +50,7 @@ export function createTest(options: Partial<TestOptions>): TestHooks {
     }
 
     if (ctx.options.server) {
-      await startServer()
+      await startServer(ctx.options.env)
     }
 
     if (ctx.options.waitFor) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,6 +1,7 @@
 import type { Nuxt, NuxtConfig } from '@nuxt/schema'
 import type { ExecaChildProcess } from 'execa'
 import type { Browser, LaunchOptions } from 'playwright-core'
+import type { StartServerOptions } from './server'
 
 export type TestRunner = 'vitest' | 'jest' | 'cucumber'
 
@@ -24,6 +25,7 @@ export interface TestOptions {
   }
   server: boolean
   port?: number
+  env?: StartServerOptions['env']
 }
 
 export interface TestContext {


### PR DESCRIPTION
Hi,

I noticed that the nuxt server launched by the playwright fixture always uses the current environment variables without the option to overwrite them. So I exposed the already existing option to overwrite them from the startServer command into the playwright config. This way it's possible to define env variables to use during testing either globally or even overwrite them per test.

Example:
```ts
export default defineConfig<ConfigOptions>({
  use: {
    nuxt: {
      rootDir: fileURLToPath(new URL(".", import.meta.url)),
      env: {
        // Overwrite backend url during tests. This way the .env can still contain the real one used during development.
        NUXT_BACKEND_URL: "http://mocked-backend.example/api",
      },
    },
  },
});
```