### PR TITLE
fix: avoid error message with tsc and nuxt test-utils

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -23,7 +23,7 @@ export interface NuxtVitestOptions {
  * List of plugins that are not compatible with test env.
  * Hard-coded for now, should remove by PR to upstream.
  */
-const vitePluginBlocklist = ['vite-plugin-vue-inspector', 'vite-plugin-vue-inspector:post', 'vite-plugin-inspect']
+const vitePluginBlocklist = ['vite-plugin-vue-inspector', 'vite-plugin-vue-inspector:post', 'vite-plugin-inspect', 'nuxt:type-check']
 
 export default defineNuxtModule<NuxtVitestOptions>({
   meta: {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

An error message like this appears:

[1:39:59 PM]  ERROR  1:39:59 PM [vite] Pre-transform error: Failed to resolve import "/@vite-plugin-checker-runtime-entry" from "node_modules/nuxt/dist/app/entry.js". Does the file exist?

With a empty nuxt project and the following config:

```bash
npm i --save-dev @nuxt/test-utils vitest @vue/test-utils happy-dom playwright-core
npm i --save-dev @vitest/ui
npm i --save-dev vue-tsc typescript
```

```ts
export default defineNuxtConfig({
  compatibilityDate: "2024-04-03",
  devtools: { enabled: true },
  modules: ["@nuxt/test-utils"],
  typescript: {
    typeCheck: true,
  },
  testUtils: {
    startOnBoot: true,
  },
})
```

See this reproduction link: https://stackblitz.com/edit/github-hxk7b6