### PR TITLE
chore: Add 'MIT' license to vitest-environment-nuxt package.json

### DIFF
--- a/stubs/vitest-environment-nuxt/package.json
+++ b/stubs/vitest-environment-nuxt/package.json
@@ -2,6 +2,7 @@
   "type": "module",
   "name": "vitest-environment-nuxt",
   "version": "1.0.0",
+  "license": "MIT",
   "exports": {
     ".": "./index.mjs",
     "./utils": "./utils.mjs"


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A small change to ensure the `"license": "MIT"` is included in `stubs/vitest-environment-nuxt/package.json` - primarily done so that automated license scanning tools can look in the `package.json` and confirm the correct license to ensure a project doesn't accidentally use a potentially dangerous license (for closed source work).

An example of such a license finder can be found here: [LicenseFInder](https://github.com/pivotal/LicenseFinder/tree/master).

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
