### PR TITLE
fix(runtime-utils): pass global `directives` to `mountSuspended`

### DIFF
--- a/examples/app-vitest-full/components/DirectiveComponent.vue
+++ b/examples/app-vitest-full/components/DirectiveComponent.vue
@@ -1,0 +1,3 @@
+<template>
+  <div v-sample-directive />
+</template>

--- a/examples/app-vitest-full/plugins/directive.ts
+++ b/examples/app-vitest-full/plugins/directive.ts
@@ -1,0 +1,7 @@
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.directive('sample-directive', {
+    created(el: Element) {
+      el.setAttribute('data-directive', 'true')
+    },
+  })
+})

--- a/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
@@ -15,6 +15,7 @@ import ExportDefaultWithRenderComponent from '~/components/ExportDefaultWithRend
 import ExportDefaultReturnsRenderComponent from '~/components/ExportDefaultReturnsRenderComponent.vue'
 
 import { BoundAttrs } from '#components'
+import DirectiveComponent from '~/components/DirectiveComponent.vue'
 
 const formats = {
   ExportDefaultComponent,
@@ -116,6 +117,11 @@ describe('mountSuspended', () => {
     expect(component.vm.testExpose?.()).toBe('expose was successful')
     // @ts-expect-error FIXME: someRef is typed as unwrapped
     expect(component.vm.someRef.value).toBe('thing')
+  })
+
+  it('respects directives registered in nuxt plugins', async () => {
+    const component = await mountSuspended(DirectiveComponent)
+    expect(component.html()).toMatchInlineSnapshot(`"<div data-directive="true"></div>"`)
   })
 })
 

--- a/src/runtime-utils/mount.ts
+++ b/src/runtime-utils/mount.ts
@@ -145,6 +145,7 @@ export async function mountSuspended<T>(
               config: {
                 globalProperties: vueApp.config.globalProperties,
               },
+              directives: vueApp._context.directives,
               provide: vueApp._context.provides,
               stubs: {
                 Suspense: false,


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/test-utils/issues/959

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Custom vue directives, typically added through a nuxt plugin, are not available in the testing environment.

For example the following plugin defines a custom uppercase directive:
```
export default defineNuxtPlugin(({ vueApp }) => {
  vueApp.directive('uppercase', {
    mounted: (el, binding, node) => {
      // ...impl code
    },
  })
})
```
However when running tests the below warning can be observed:
```
[Vue warn]: Failed to resolve directive: uppercase
  at <MountSuspendedComponent >
  at <MountSuspendedHelper>
  at <Anonymous ref="VTU_COMPONENT" >
  at <VTUROOT>
[Vue warn]: Failed to resolve directive: uppercase 
  at <MountSuspendedComponent > 
  at <MountSuspendedHelper> 
  at <Anonymous ref="VTU_COMPONENT" > 
  at <VTUROOT>
```

