### PR TITLE
fix(e2e): set `NODE_ENV` when running built server

### DIFF
--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -16,6 +16,7 @@ export function createTestContext(options: Partial<TestOptions>): TestContext {
     logLevel: 1,
     server: true,
     build: (options.browser !== false) || (options.server !== false),
+    env: {},
     nuxtConfig: {
       // suppress compatibility date warning for runtime environment tests
       compatibilityDate: '2024-04-03' as DateString,
@@ -24,6 +25,10 @@ export function createTestContext(options: Partial<TestOptions>): TestContext {
       type: 'chromium' as const,
     },
   } satisfies Partial<TestOptions>)
+
+  if (!_options.dev) {
+    _options.env!.NODE_ENV ||= 'production'
+  }
 
   // Disable build and server if endpoint is provided
   if (_options.host) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

setting `NODE_ENV` is necessary when running a built nuxt server as it affects how dependencies are resolved - and even runtime behaviour (whether vue router logs errors, for example)