### PR TITLE
fix(runtime-utils): support `defineModel` in `mountSuspended`

### DIFF
--- a/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
@@ -99,15 +99,13 @@ describe('mountSuspended', () => {
     `)
   })
 
-  // This test works (you can delete it later)
   it('can receive emitted events from components using defineModel', () => {
     const component = mount(WrapperTests)
     component.find('button#changeModelValue').trigger('click')
     expect(component.emitted()).toHaveProperty('update:modelValue')
   })
 
-  // FIXME: fix this failing test
-  it.todo('can receive emitted events from components mounted within nuxt suspense using defineModel', async () => {
+  it('can receive emitted events from components mounted within nuxt suspense using defineModel', async () => {
     const component = await mountSuspended(WrapperTests)
     component.find('button#changeModelValue').trigger('click')
     expect(component.emitted()).toHaveProperty('update:modelValue')

--- a/src/runtime-utils/mount.ts
+++ b/src/runtime-utils/mount.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import type { ComponentMountingOptions } from '@vue/test-utils'
-import { Suspense, h, isReadonly, nextTick, reactive, unref } from 'vue'
+import { Suspense, h, isReadonly, nextTick, reactive, unref, getCurrentInstance } from 'vue'
 import type { DefineComponent, SetupContext } from 'vue'
 import { defu, createDefu } from 'defu'
 import type { RouteLocationRaw } from 'vue-router'
@@ -116,6 +116,11 @@ export async function mountSuspended<T>(
                         ...component,
                         render: render
                           ? function (this: unknown, _ctx: Record<string, unknown>, ...args: unknown[]) {
+                            // When using defineModel, getCurrentInstance().emit is executed internally. it needs to override.
+                            const currentInstance = getCurrentInstance()
+                            if (currentInstance) {
+                              currentInstance.emit = setupContext.emit
+                            }
                             // Set before setupState set to allow asyncData to overwrite data
                             if (data && typeof data === 'function') {
                               // @ts-expect-error error TS2554: Expected 1 arguments, but got 0


### PR DESCRIPTION
### 🔗 Linked issue
resolve: https://github.com/nuxt/test-utils/issues/572
 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
When using defineModel, getCurrentInstance().emit is executed internally. Therefore, it needs to be overridden.
https://github.com/vuejs/core/blob/main/packages/runtime-core/src/helpers/useModel.ts#L85

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
