### PR TITLE
fix(vitest-environment): suppress suspense warning

### DIFF
--- a/src/environments/vitest/index.ts
+++ b/src/environments/vitest/index.ts
@@ -25,6 +25,14 @@ export default <Environment>{
       environmentOptions?.nuxtRuntimeConfig.app?.baseURL || '/',
     )
 
+    const consoleInfo = console.info
+    console.info = (...args) => {
+      if (args[0] === '<Suspense> is an experimental feature and its API will likely change.') {
+        return
+      }
+      return consoleInfo(...args)
+    }
+
     const environmentName = environmentOptions.nuxt.domEnvironment as NuxtBuiltinEnvironment
     const environment = environmentMap[environmentName] || environmentMap['happy-dom']
     const { window: win, teardown } = await environment(global, defu(environmentOptions, {
@@ -150,6 +158,7 @@ export default <Environment>{
       teardown() {
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
         keys.forEach(key => delete global[key])
+        console.info = consoleInfo
         originals.forEach((v, k) => (global[k] = v))
         teardown()
       },


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This makes tests less noisy by suppressing the `<Suspense> is an experimental feature and its API will likely change.` warning that we're probably all too familiar with by this point. It's not relevant to _testing_ in any case, and it will still be visible in the browser when developing.