### PR TITLE
fix: remove `setInterval` from the presets

### DIFF
--- a/examples/app-vitest-full/tests/nuxt/auto-import.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/auto-import.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 describe('auto-imports', () => {
   it('can use core nuxt composables within test file', () => {
@@ -16,5 +16,18 @@ describe('auto-imports', () => {
   it('should not mock imports that are mocked in another test file', () => {
     expect(useAutoImportedTarget()).toMatchInlineSnapshot('"the original"')
     expect(useAutoImportedNonTarget()).toMatchInlineSnapshot('"the original"')
+  })
+
+  it('setInterval is not auto-imported', () => {
+    vi.useFakeTimers()
+
+    let triggerd = false
+    setInterval(() => {
+      triggerd = true
+    }, 1000)
+
+    vi.advanceTimersByTime(1000)
+
+    expect(triggerd).toBe(true)
   })
 })

--- a/src/module/mock.ts
+++ b/src/module/mock.ts
@@ -28,6 +28,14 @@ export function setupImportMocking() {
     ctx.components = _
   })
 
+  nuxt.hook('imports:sources', (presets) => {
+    // because the native setInterval cannot be mocked
+    const idx = presets.findIndex(p => p.imports.includes('setInterval'))
+    if (idx !== -1) {
+      presets.splice(idx, 1)
+    }
+  })
+
   // We want to run Nuxt plugins on test files
   nuxt.options.ignore = nuxt.options.ignore.filter(i => i !== '**/*.{spec,test}.{js,cts,mts,ts,jsx,tsx}')
   if (nuxt._ignore) {


### PR DESCRIPTION
### 🔗 Linked issue
Fixes: https://github.com/nuxt/test-utils/issues/897
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The `setInterval` overridden by Nuxt is auto-imported, so it can no longer be mocked with `useFakeTimers`. 
(`setInterval = window.setInterval`, but the previous state is retained.)

I think updating the documentation with a method like separating workspaces as shown below is one possible approach, but which would be more appropriate?
https://stackblitz.com/edit/github-agxb9y-slbn4d

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
