### PR TITLE
fix: overwrite object props in the same way as `mount`

### DIFF
--- a/examples/app-vitest-full/components/ExportDefaultComponent.vue
+++ b/examples/app-vitest-full/components/ExportDefaultComponent.vue
@@ -8,6 +8,7 @@
       :key="item"
     >{{ item }}
     </span>
+    <span>myObjProp: {{ JSON.stringify(myObjProp) }}</span>
   </div>
 </template>
 
@@ -30,6 +31,10 @@ export default {
     myArrayProp: {
       type: Array as PropType<string[]>,
       default: () => ([]),
+    },
+    myObjProp: {
+      type: Object as PropType<{ title: string }>,
+      default: () => ({}),
     },
   },
   setup(props) {

--- a/examples/app-vitest-full/components/ExportDefaultReturnsRenderComponent.vue
+++ b/examples/app-vitest-full/components/ExportDefaultReturnsRenderComponent.vue
@@ -9,6 +9,10 @@ export default {
       type: Array as PropType<string[]>,
       default: () => ([]),
     },
+    myObjProp: {
+      type: Object as PropType<{ title: string }>,
+      default: () => ({}),
+    },
   },
   setup(props) {
     const pre = 'X' + props.myProp
@@ -17,6 +21,7 @@ export default {
       h('pre', props.myProp),
       h('pre', pre),
       props.myArrayProp.map(item => h('span', item)),
+      h('span', `myObjProp: ${JSON.stringify(props.myObjProp)}`),
     ])
   },
 }

--- a/examples/app-vitest-full/components/ExportDefaultWithRenderComponent.vue
+++ b/examples/app-vitest-full/components/ExportDefaultWithRenderComponent.vue
@@ -9,6 +9,10 @@ export default {
       type: Array as PropType<string[]>,
       default: () => ([]),
     },
+    myObjProp: {
+      type: Object as PropType<{ title: string }>,
+      default: () => ({}),
+    },
   },
   setup(props) {
     return {
@@ -21,6 +25,7 @@ export default {
       h('pre', this.myProp),
       h('pre', this.setupMyProp),
       this.myArrayProp.map(item => h('span', item)),
+      h('span', `myObjProp: ${JSON.stringify(this.myObjProp)}`),
     ])
   },
 }

--- a/examples/app-vitest-full/components/ExportDefineComponent.vue
+++ b/examples/app-vitest-full/components/ExportDefineComponent.vue
@@ -7,6 +7,7 @@
       v-for="item in myArrayProp"
       :key="item"
     >{{ item }}</span>
+    <span>myObjProp: {{ JSON.stringify(myObjProp) }}</span>
   </div>
 </template>
 
@@ -29,6 +30,10 @@ export default defineComponent({
     myArrayProp: {
       type: Array as PropType<string[]>,
       default: () => ([]),
+    },
+    myObjProp: {
+      type: Object as PropType<{ title: string }>,
+      default: () => ({}),
     },
   },
   setup(props) {

--- a/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
@@ -199,6 +199,7 @@ describe.each(Object.entries(formats))(`%s`, (name, component) => {
       props: {
         myProp: 'Hello nuxt-vitest',
         myArrayProp: ['hello', 'nuxt', 'vitest'],
+        myObjProp: { title: 'Hello nuxt/test-utils' },
       },
     })
   })
@@ -206,7 +207,7 @@ describe.each(Object.entries(formats))(`%s`, (name, component) => {
   it('mounts with props', () => {
     expect(wrapper.html()).toEqual(`
 <div>
-  <h1>${name}</h1><pre>Hello nuxt-vitest</pre><pre>XHello nuxt-vitest</pre><span>hello</span><span>nuxt</span><span>vitest</span>
+  <h1>${name}</h1><pre>Hello nuxt-vitest</pre><pre>XHello nuxt-vitest</pre><span>hello</span><span>nuxt</span><span>vitest</span><span>myObjProp: {"title":"Hello nuxt/test-utils"}</span>
 </div>
     `.trim())
   })
@@ -217,7 +218,7 @@ describe.each(Object.entries(formats))(`%s`, (name, component) => {
     })
     expect(wrapper.html()).toEqual(`
 <div>
-  <h1>${name}</h1><pre>updated title</pre><pre>XHello nuxt-vitest</pre><span>hello</span><span>nuxt</span><span>vitest</span>
+  <h1>${name}</h1><pre>updated title</pre><pre>XHello nuxt-vitest</pre><span>hello</span><span>nuxt</span><span>vitest</span><span>myObjProp: {"title":"Hello nuxt/test-utils"}</span>
 </div>
     `.trim())
   })
@@ -229,7 +230,19 @@ describe.each(Object.entries(formats))(`%s`, (name, component) => {
     })
     expect(wrapper.html()).toEqual(`
 <div>
-  <h1>${name}</h1><pre>updated title</pre><pre>XHello nuxt-vitest</pre><span>updated</span><span>prop</span>
+  <h1>${name}</h1><pre>updated title</pre><pre>XHello nuxt-vitest</pre><span>updated</span><span>prop</span><span>myObjProp: {"title":"Hello nuxt/test-utils"}</span>
+</div>
+    `.trim())
+  })
+
+  it('can be updated object with setProps', async () => {
+    await wrapper.setProps({
+      myProp: 'updated title',
+      myObjProp: {},
+    })
+    expect(wrapper.html()).toEqual(`
+<div>
+  <h1>${name}</h1><pre>updated title</pre><pre>XHello nuxt-vitest</pre><span>hello</span><span>nuxt</span><span>vitest</span><span>myObjProp: {}</span>
 </div>
     `.trim())
   })

--- a/examples/app-vitest-full/tests/nuxt/render-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/render-suspended.spec.ts
@@ -169,13 +169,14 @@ describe.each(Object.entries(formats))(`%s`, (name, component) => {
     const wrapper = await renderSuspended(component, {
       props: {
         myProp: 'Hello nuxt-vitest',
+        myObjProp: { title: 'Hello nuxt/test-utils' },
       },
     })
 
     expect(wrapper.html()).toEqual(`
 <div id="test-wrapper">
   <div>
-    <h1>${name}</h1><pre>Hello nuxt-vitest</pre><pre>XHello nuxt-vitest</pre>
+    <h1>${name}</h1><pre>Hello nuxt-vitest</pre><pre>XHello nuxt-vitest</pre><span>myObjProp: {"title":"Hello nuxt/test-utils"}</span>
   </div>
 </div>
     `.trim())

--- a/src/runtime-utils/mount.ts
+++ b/src/runtime-utils/mount.ts
@@ -166,7 +166,7 @@ export async function mountSuspended<T>(
                         setup: setup ? (props: Record<string, unknown>) => wrappedSetup(props, setupContext) : undefined,
                       }
 
-                      return () => h(clonedComponent, { ...defuReplaceArray(setProps, props) as typeof props, ...attrs }, slots)
+                      return () => h(clonedComponent, { ...customMerge(setProps, props) as typeof props, ...attrs }, slots)
                     },
                   }),
               },
@@ -201,11 +201,9 @@ interface AugmentedVueInstance {
   __setProps?: (props: Record<string, unknown>) => void
 }
 
-const defuReplaceArray = createDefu((obj, key, value) => {
-  if (Array.isArray(obj[key])) {
-    obj[key] = value
-    return true
-  }
+const customMerge = createDefu((obj, key, value) => {
+  obj[key] = value
+  return true
 })
 
 function cloneProps(props: Record<string, unknown>) {


### PR DESCRIPTION
### 🔗 Linked issue
Fixes: https://github.com/nuxt/test-utils/issues/1072
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In `defu`, the first argument takes precedence, so it is not overwritten. 
With this fix, props can now be overwritten just like in `mount`.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
