### PR TITLE
fix(runtime-utils): pass custom global components to mountSuspended

### DIFF
--- a/examples/app-vitest-full/components/CustomComponent.vue
+++ b/examples/app-vitest-full/components/CustomComponent.vue
@@ -1,0 +1,3 @@
+<template>
+  <custom-test-button />
+</template>

--- a/examples/app-vitest-full/plugins/component.ts
+++ b/examples/app-vitest-full/plugins/component.ts
@@ -1,0 +1,5 @@
+import TestButton from '~/components/TestButton.vue'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.component('custom-test-button', TestButton)
+})

--- a/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
@@ -20,6 +20,7 @@ import ComponentWithImports from '~/components/ComponentWithImports.vue'
 
 import { BoundAttrs } from '#components'
 import DirectiveComponent from '~/components/DirectiveComponent.vue'
+import CustomComponent from '~/components/CustomComponent.vue'
 
 const formats = {
   ExportDefaultComponent,
@@ -130,6 +131,11 @@ describe('mountSuspended', () => {
   it('respects directives registered in nuxt plugins', async () => {
     const component = await mountSuspended(DirectiveComponent)
     expect(component.html()).toMatchInlineSnapshot(`"<div data-directive="true"></div>"`)
+  })
+
+  it('respects custom component registered in nuxt plugins', async () => {
+    const component = await mountSuspended(CustomComponent)
+    expect(component.html()).toMatchInlineSnapshot(`"<button data-testid="test-button"> Button in TestButton component </button>"`)
   })
 
   it('can handle reserved words in component props', async () => {

--- a/src/runtime-utils/mount.ts
+++ b/src/runtime-utils/mount.ts
@@ -187,7 +187,7 @@ export async function mountSuspended<T>(
                 MountSuspendedHelper: false,
                 [component && typeof component === 'object' && 'name' in component && typeof component.name === 'string' ? component.name : 'MountSuspendedComponent']: false,
               },
-              components: { RouterLink },
+              components: { ...vueApp._context.components, RouterLink },
             },
           } satisfies ComponentMountingOptions<T>,
         ) as ComponentMountingOptions<T>,


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1080 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Custom vue components, typically added through a nuxt plugin, are not available in the testing environment.

sample:
```
export default defineNuxtPlugin(nuxtApp => {
  nuxtApp.vueApp.component('font-awesome-icon', FontAwesomeIcon);
});
```

when running a test and mounting a component that uses `<font-awesome-icon>`:
```
[Vue warn]: Failed to resolve component: font-awesome-icon
```
