### PR TITLE
fix(runtim-utils): do not use `defu` for merging

### DIFF
--- a/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
@@ -252,6 +252,30 @@ describe.each(Object.entries(formats))(`%s`, (name, component) => {
 </div>
     `.trim())
   })
+
+  it('can be updated to null with setProps', async () => {
+    await wrapper.setProps({
+      myProp: 'updated title',
+      myObjProp: null,
+    })
+    expect(wrapper.html()).toEqual(`
+<div>
+  <h1>${name}</h1><pre>updated title</pre><pre>XHello nuxt-vitest</pre><span>hello</span><span>nuxt</span><span>vitest</span><span>myObjProp: null</span>
+</div>
+    `.trim())
+  })
+
+  it('can be updated to undefined with setProps', async () => {
+    await wrapper.setProps({
+      myProp: 'updated title',
+      myObjProp: undefined,
+    })
+    expect(wrapper.html()).toEqual(`
+<div>
+  <h1>${name}</h1><pre>updated title</pre><pre>XHello nuxt-vitest</pre><span>hello</span><span>nuxt</span><span>vitest</span><span>myObjProp: {}</span>
+</div>
+    `.trim())
+  })
 })
 
 it('renders links correctly', async () => {

--- a/src/runtime-utils/mount.ts
+++ b/src/runtime-utils/mount.ts
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils'
 import type { ComponentMountingOptions } from '@vue/test-utils'
 import { Suspense, h, isReadonly, nextTick, reactive, unref, getCurrentInstance } from 'vue'
 import type { DefineComponent, SetupContext } from 'vue'
-import { defu, createDefu } from 'defu'
+import { defu } from 'defu'
 import type { RouteLocationRaw } from 'vue-router'
 
 import { RouterLink } from './components/RouterLink'
@@ -166,7 +166,7 @@ export async function mountSuspended<T>(
                         setup: setup ? (props: Record<string, unknown>) => wrappedSetup(props, setupContext) : undefined,
                       }
 
-                      return () => h(clonedComponent, { ...customMerge(setProps, props) as typeof props, ...attrs }, slots)
+                      return () => h(clonedComponent, { ...props, ...setProps, ...attrs }, slots)
                     },
                   }),
               },
@@ -200,11 +200,6 @@ interface AugmentedVueInstance {
   setupState?: Record<string, unknown>
   __setProps?: (props: Record<string, unknown>) => void
 }
-
-const customMerge = createDefu((obj, key, value) => {
-  obj[key] = value
-  return true
-})
 
 function cloneProps(props: Record<string, unknown>) {
   const newProps = reactive<Record<string, unknown>>({})


### PR DESCRIPTION
### 🔗 Linked issue
ref: https://github.com/nuxt/test-utils/pull/1078
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
There were cases where `setProps` could not overwrite when `defu` was used. 
Therefore, the merging of props will no longer use `defu`.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
