### PR TITLE
fix(runtime-utils): proxy wrapper props

### DIFF
--- a/examples/app-vitest-full/components/ExportDefaultComponent.vue
+++ b/examples/app-vitest-full/components/ExportDefaultComponent.vue
@@ -33,7 +33,7 @@ export default {
       default: () => ([]),
     },
     myObjProp: {
-      type: Object as PropType<{ title: string }>,
+      type: [Object, null, {}] as PropType<{ title: string } | null | object>,
       default: () => ({}),
     },
   },

--- a/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
@@ -198,7 +198,7 @@ describe('mountSuspended', () => {
 })
 
 describe.each(Object.entries(formats))(`%s`, (name, component) => {
-  let wrapper: VueWrapper<unknown>
+  let wrapper: VueWrapper<InstanceType<typeof component>>
 
   beforeEach(async () => {
     wrapper = await mountSuspended(component, {
@@ -216,6 +216,14 @@ describe.each(Object.entries(formats))(`%s`, (name, component) => {
   <h1>${name}</h1><pre>Hello nuxt-vitest</pre><pre>XHello nuxt-vitest</pre><span>hello</span><span>nuxt</span><span>vitest</span><span>myObjProp: {"title":"Hello nuxt/test-utils"}</span>
 </div>
     `.trim())
+
+    expect(wrapper.props()).toEqual({
+      myProp: 'Hello nuxt-vitest',
+      myArrayProp: ['hello', 'nuxt', 'vitest'],
+      myObjProp: { title: 'Hello nuxt/test-utils' },
+    })
+
+    expect(wrapper.props('myProp')).toBe('Hello nuxt-vitest')
   })
 
   it('can be updated with setProps', async () => {
@@ -227,6 +235,12 @@ describe.each(Object.entries(formats))(`%s`, (name, component) => {
   <h1>${name}</h1><pre>updated title</pre><pre>XHello nuxt-vitest</pre><span>hello</span><span>nuxt</span><span>vitest</span><span>myObjProp: {"title":"Hello nuxt/test-utils"}</span>
 </div>
     `.trim())
+
+    expect(wrapper.props()).toEqual({
+      myProp: 'updated title',
+      myArrayProp: ['hello', 'nuxt', 'vitest'],
+      myObjProp: { title: 'Hello nuxt/test-utils' },
+    })
   })
 
   it('can be updated array with setProps', async () => {

--- a/src/runtime-utils/mount.ts
+++ b/src/runtime-utils/mount.ts
@@ -96,6 +96,12 @@ export async function mountSuspended<T>(
                     (vm as unknown as AugmentedVueInstance).__setProps = (props: Record<string, unknown>) => {
                       Object.assign(setProps, props)
                     }
+                    vm.props = new Proxy(vm.props, {
+                      apply: (target, thisValue, args) => {
+                        const component = thisValue.findComponent({ name: 'MountSuspendedComponent' })
+                        return component.props(...args)
+                      },
+                    })
                     resolve(vm as ReturnType<typeof mount<T>> & { setupState: Record<string, unknown> })
                   }),
               },


### PR DESCRIPTION
### 🔗 Linked issue
Fixes: https://github.com/nuxt/test-utils/issues/1064

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
When using `mountSuspended`, `wrapper.props` returns the props of the wrapped component instead of the specified component. 
To address this, proxy `wrapper.props` so that it returns the props of the `MountSuspendedComponent`.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
