### PR TITLE
fix(runtime-utils): define `$attrs` in component render context

### DIFF
--- a/examples/app-vitest-full/components/ComponentWithAttrs.vue
+++ b/examples/app-vitest-full/components/ComponentWithAttrs.vue
@@ -1,0 +1,9 @@
+<template>
+  <span v-bind="$attrs" />
+</template>
+
+<script setup lang="ts">
+defineOptions({
+  inheritAttrs: false,
+})
+</script>

--- a/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
@@ -14,6 +14,7 @@ import ExportDefineComponent from '~/components/ExportDefineComponent.vue'
 import ExportDefaultWithRenderComponent from '~/components/ExportDefaultWithRenderComponent.vue'
 import ExportDefaultReturnsRenderComponent from '~/components/ExportDefaultReturnsRenderComponent.vue'
 import OptionsApiPage from '~/pages/other/options-api.vue'
+import ComponentWithAttrs from '~/components/ComponentWithAttrs.vue'
 import ComponentWithReservedProp from '~/components/ComponentWithReservedProp.vue'
 import ComponentWithReservedState from '~/components/ComponentWithReservedState.vue'
 import ComponentWithImports from '~/components/ComponentWithImports.vue'
@@ -157,6 +158,11 @@ describe('mountSuspended', () => {
     const comp = await mountSuspended(ComponentWithReservedState)
     const span = comp.find('span')
     expect(span.text()).toBe('false')
+  })
+
+  it('should define $attrs', async () => {
+    const component = await mountSuspended(ComponentWithAttrs, { attrs: { foo: 'bar' } })
+    expect(component.find('[foo="bar"]').exists()).toBe(true)
   })
 
   describe('Options API', () => {

--- a/examples/app-vitest-full/tests/nuxt/render-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/render-suspended.spec.ts
@@ -11,6 +11,7 @@ import DirectiveComponent from '~/components/DirectiveComponent.vue'
 
 import ExportDefaultComponent from '~/components/ExportDefaultComponent.vue'
 import ExportDefineComponent from '~/components/ExportDefineComponent.vue'
+import ComponentWithAttrs from '~/components/ComponentWithAttrs.vue'
 import ExportDefaultWithRenderComponent from '~/components/ExportDefaultWithRenderComponent.vue'
 import ExportDefaultReturnsRenderComponent from '~/components/ExportDefaultReturnsRenderComponent.vue'
 import OptionsApiPage from '~/pages/other/options-api.vue'
@@ -123,6 +124,13 @@ describe('renderSuspended', () => {
           [],
         ],
       }
+    `)
+  })
+
+  it('should define $attrs', async () => {
+    const { html } = await renderSuspended(ComponentWithAttrs, { attrs: { foo: 'bar' } })
+    expect(html()).toMatchInlineSnapshot(`
+      "<div id="test-wrapper"><span foo="bar"></span></div>"
     `)
   })
 

--- a/src/runtime-utils/mount.ts
+++ b/src/runtime-utils/mount.ts
@@ -182,6 +182,7 @@ export async function mountSuspended<T>(
           _options,
           {
             slots,
+            attrs,
             global: {
               config: {
                 globalProperties: vueApp.config.globalProperties,

--- a/src/runtime-utils/render.ts
+++ b/src/runtime-utils/render.ts
@@ -1,4 +1,4 @@
-import { Suspense, effectScope, h, nextTick, isReadonly, reactive, unref } from 'vue'
+import { Suspense, effectScope, h, nextTick, isReadonly, reactive, unref, defineComponent } from 'vue'
 import type { DefineComponent, SetupContext } from 'vue'
 import type { RenderOptions as TestingLibraryRenderOptions } from '@testing-library/vue'
 import { defu } from 'defu'
@@ -85,6 +85,12 @@ export async function renderSuspended<T>(component: T, options?: RenderOptions<T
     }
   }
 
+  const WrapperComponent = defineComponent({
+    inheritAttrs: false,
+    render() {
+      return h('div', { id: WRAPPER_EL_ID }, this.$slots.default?.())
+    },
+  })
   return new Promise<ReturnType<typeof renderFromTestingLibrary> & { setupState: SetupState }>((resolve) => {
     const utils = renderFromTestingLibrary(
       {
@@ -108,8 +114,7 @@ export async function renderSuspended<T>(component: T, options?: RenderOptions<T
           // we add this additional root element because otherwise testing-library breaks
           // because there's no root element while Suspense is resolving
           h(
-            'div',
-            { id: WRAPPER_EL_ID },
+            WrapperComponent,
             h(
               Suspense,
               {
@@ -190,6 +195,7 @@ export async function renderSuspended<T>(component: T, options?: RenderOptions<T
       },
       defu(_options, {
         slots,
+        attrs,
         global: {
           config: {
             globalProperties: vueApp.config.globalProperties,


### PR DESCRIPTION
### 🔗 Linked issue
Resolves #1092 

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Fixes an issue where `$attrs`  are undefined when mounting a component using `mountSuspended` .

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
