### PR TITLE
fix: add proxy `wrapper.element`

### DIFF
--- a/examples/app-vitest-full/components/WrapperElement.vue
+++ b/examples/app-vitest-full/components/WrapperElement.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+defineProps<{
+  as: string
+}>()
+</script>
+
+<template>
+  <component
+    :is="as"
+    v-bind="$attrs"
+  />
+</template>

--- a/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
@@ -21,6 +21,7 @@ import ComponentWithImports from '~/components/ComponentWithImports.vue'
 import { BoundAttrs } from '#components'
 import DirectiveComponent from '~/components/DirectiveComponent.vue'
 import CustomComponent from '~/components/CustomComponent.vue'
+import WrapperElement from '~/components/WrapperElement.vue'
 
 const formats = {
   ExportDefaultComponent,
@@ -296,4 +297,14 @@ it('renders links correctly', async () => {
   const component = await mountSuspended(LinkTests)
 
   expect(component.html()).toMatchInlineSnapshot(`"<div><a href="/test"> Link with string to prop </a><a href="/test"> Link with object to prop </a></div>"`)
+})
+
+it('element should be changed', async () => {
+  const component = await mountSuspended(WrapperElement, { props: { as: 'div' } })
+
+  expect(component.element.tagName).toBe('DIV')
+
+  await component.setProps({ as: 'span' })
+
+  expect(component.element.tagName).toBe('SPAN')
 })

--- a/src/runtime-utils/mount.ts
+++ b/src/runtime-utils/mount.ts
@@ -96,13 +96,7 @@ export async function mountSuspended<T>(
                     (vm as unknown as AugmentedVueInstance).__setProps = (props: Record<string, unknown>) => {
                       Object.assign(setProps, props)
                     }
-                    vm.props = new Proxy(vm.props, {
-                      apply: (target, thisValue, args) => {
-                        const component = thisValue.findComponent({ name: 'MountSuspendedComponent' })
-                        return component.props(...args)
-                      },
-                    })
-                    resolve(vm as ReturnType<typeof mount<T>> & { setupState: Record<string, unknown> })
+                    resolve(wrappedMountedWrapper(vm as ReturnType<typeof mount<T>> & { setupState: Record<string, unknown> }))
                   }),
               },
               {
@@ -213,4 +207,29 @@ function cloneProps(props: Record<string, unknown>) {
     newProps[key] = props[key]
   }
   return newProps
+}
+
+function wrappedMountedWrapper<T>(wrapper: ReturnType<typeof mount<T>> & { setupState: Record<string, unknown> }) {
+  const proxy = new Proxy(wrapper, {
+    get: (target, prop, receiver) => {
+      if (prop === 'element') {
+        const component = target.findComponent({ name: 'MountSuspendedComponent' })
+        return component[prop]
+      }
+      else {
+        return Reflect.get(target, prop, receiver)
+      }
+    },
+  })
+
+  for (const key of ['props'] as const) {
+    proxy[key] = new Proxy(wrapper[key], {
+      apply: (target, thisArg, args) => {
+        const component = thisArg.findComponent({ name: 'MountSuspendedComponent' })
+        return component[key](...args)
+      },
+    })
+  }
+
+  return proxy
 }


### PR DESCRIPTION
### 🔗 Linked issue
resolves: https://github.com/nuxt/test-utils/issues/1091
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
`wrapper.element` returned by `mountSuspended` returns the element of `NuxtRoot`, so use a proxy to return the element of the target component.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
