### PR TITLE
`environmentmatchglobs` deprecated API in Vitest 3

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -120,9 +120,13 @@ export async function getVitestConfigFromNuxt(
             options.nuxt.options.nitro?.routeRules,
           ),
         },
-        environmentMatchGlobs: [
-          ['**/*.nuxt.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}', 'nuxt'],
-          ['{test,tests}/nuxt/**.*', 'nuxt'],
+        workspace: [
+          {
+            extends: true,
+            test: {
+              environment: 'jsdom',
+            },
+          },
         ],
         server: {
           deps: {


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1123

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Followed the Vitest docs here: https://vitest.dev/config/#environmentmatchglobs
And fixed the deprecated API environmentmatchglobs