### PR TITLE
fix(runtime-utils): ensure event listeners props are called

### DIFF
--- a/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
@@ -123,6 +123,19 @@ describe('mountSuspended', () => {
     expect(component.emitted()).toHaveProperty('update:modelValue')
   })
 
+  it('can pass onUpdate event to components using defineModel', async () => {
+    const component = await mountSuspended(WrapperTests, {
+      props: {
+        'onUpdate:modelValue': async e => component.setProps({ modelValue: e }),
+      },
+    })
+
+    component.find('button#changeModelValue').trigger('click')
+    expect(component.emitted()).toHaveProperty('update:modelValue')
+    await nextTick()
+    expect(component.props('modelValue')).toBe(true)
+  })
+
   it('can access exposed methods/refs from components mounted within nuxt suspense', async () => {
     const component = await mountSuspended(WrapperTests)
     expect(component.vm.testExpose?.()).toBe('expose was successful')

--- a/src/runtime-utils/mount.ts
+++ b/src/runtime-utils/mount.ts
@@ -116,7 +116,11 @@ export async function mountSuspended<T>(
                             // When using defineModel, getCurrentInstance().emit is executed internally. it needs to override.
                             const currentInstance = getCurrentInstance()
                             if (currentInstance) {
-                              currentInstance.emit = setupContext.emit
+                              const oldEmit = currentInstance.emit
+                              currentInstance.emit = (event: string, ...args: unknown[]) => {
+                                oldEmit(event, ...args)
+                                setupContext.emit(event, ...args)
+                              }
                             }
                             // Set before setupState set to allow asyncData to overwrite data
                             if (data && typeof data === 'function') {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Resolved #572

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
With the change to resolve #572 the internal emit function for the component was changed to use the root component so that emits can be picked up by vitest.

This had the side-effect of breaking user-passed event listeners as props to the component:
```js
const component = await mountSuspended(MyComponent, {
  props: {
    'onUpdate:modelValue': async e => component.setProps({ modelValue: e }),
  },
})
```

To resolve this I changed the internal component emit to call both the original emit and the root component emit.
I've also added a new unit test for this case.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
