### PR TITLE
fix(vitest-environment): respect custom `app.baseURL` in manifest path

### DIFF
--- a/src/environments/vitest/index.ts
+++ b/src/environments/vitest/index.ts
@@ -116,7 +116,7 @@ export default <Environment>{
     )
     const matcher = exportMatcher(routeRulesMatcher)
     const manifestOutputPath = joinURL(
-      '/',
+      environmentOptions?.nuxtRuntimeConfig.app?.baseURL || '/',
       environmentOptions?.nuxtRuntimeConfig.app?.buildAssetsDir || '_nuxt',
       'builds',
     )


### PR DESCRIPTION
resolves https://github.com/nuxt/test-utils/issues/1212

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I'd advise against using a custom baseURL in testing but this respects it if provided.