### PR TITLE
docs: consistent URL formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -8,7 +8,7 @@ body:
         Thank you for taking the time to fill out this feature request!
 
         Please carefully read the contribution docs before suggesting a new feature
-        👉 https://nuxt.com/docs/community/contribution/#creating-an-issue
+        👉 https://nuxt.com/docs/community/contribution#creating-an-issue
   - type: textarea
     id: feature-description
     attributes:

--- a/.github/reproduire/needs-reproduction.md
+++ b/.github/reproduire/needs-reproduction.md
@@ -1,4 +1,4 @@
-Would you be able to provide a [reproduction](https://nuxt.com/docs/community/reporting-bugs/#create-a-minimal-reproduction)? 🙏
+Would you be able to provide a [reproduction](https://nuxt.com/docs/community/reporting-bugs#create-a-minimal-reproduction)? 🙏
 
 <details>
 <summary>More info</summary>
@@ -23,7 +23,7 @@ We have a couple of templates for starting with a minimal reproduction:
 
 A public GitHub repository is also perfect. 👌
 
-Please ensure that the reproduction is as **minimal** as possible. See more details [in our guide](https://nuxt.com/docs/community/reporting-bugs/#create-a-minimal-reproduction).
+Please ensure that the reproduction is as **minimal** as possible. See more details [in our guide](https://nuxt.com/docs/community/reporting-bugs#create-a-minimal-reproduction).
 
 You might also find these other articles interesting and/or helpful:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Nuxt Test Utils is currently powering [the tests we use on Nuxt itself](https://
 You can find out more about how to use Nuxt Test Utils:
 
 - in [a general overview](https://nuxt.com/docs/getting-started/testing)
-- in [an in-depth guide for module authors](https://nuxt.com/docs/guide/going-further/modules/#testing)
+- in [an in-depth guide for module authors](https://nuxt.com/docs/guide/going-further/modules#testing)
 
 ## License
 


### PR DESCRIPTION
### 🔗 Linked issue
* https://github.com/nuxt/nuxt.com/issues/1841
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This changes the URLs used in the markdown files and templates by removing trailing slashes.

This is actually a 'fix' for the link to the module authors docs page, which will show a 404 not found due to the trailing slash (tracking here https://github.com/nuxt/nuxt.com/issues/1841), until the underlying issue is resolved we can at least make sure the link works as expected 💪
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
