### PR TITLE
feat(config): support vitest workspaces with `defineVitestProject`

### DIFF
--- a/examples/app-vitest-full/vitest.config.ts
+++ b/examples/app-vitest-full/vitest.config.ts
@@ -3,7 +3,6 @@ import { defineVitestConfig } from '@nuxt/test-utils/config'
 
 export default defineVitestConfig({
   test: {
-    dir: 'tests',
     includeSource: ['../pages/index.vue'],
     environmentOptions: {
       nuxt: {

--- a/examples/app-vitest-workspace/nuxt.config.ts
+++ b/examples/app-vitest-workspace/nuxt.config.ts
@@ -1,0 +1,5 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  devtools: { enabled: true },
+  compatibilityDate: '2024-04-03',
+})

--- a/examples/app-vitest-workspace/package.json
+++ b/examples/app-vitest-workspace/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "example-app-vitest-workspace",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "nuxt build",
+    "dev": "nuxt dev",
+    "generate": "nuxt generate",
+    "preview": "nuxt preview",
+    "postinstall": "nuxt prepare",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "nuxt": "^3.16.2"
+  },
+  "devDependencies": {
+    "@nuxt/test-utils": "latest",
+    "globby": "14.1.0",
+    "happy-dom": "17.4.4",
+    "playwright-core": "1.52.0",
+    "typescript": "5.8.3",
+    "vitest": "3.1.1"
+  }
+}

--- a/examples/app-vitest-workspace/test/app.nuxt.spec.ts
+++ b/examples/app-vitest-workspace/test/app.nuxt.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+describe('my test', () => {
+  it('works', () => {
+    expect(Object.keys(useAppConfig())).toMatchInlineSnapshot(`
+      [
+        "nuxt",
+      ]
+    `)
+  })
+})

--- a/examples/app-vitest-workspace/test/index.unit.spec.ts
+++ b/examples/app-vitest-workspace/test/index.unit.spec.ts
@@ -1,0 +1,5 @@
+import { expect, it } from 'vitest'
+
+it('unit test', () => {
+  expect(typeof window).toBe('undefined')
+})

--- a/examples/app-vitest-workspace/tsconfig.json
+++ b/examples/app-vitest-workspace/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/examples/app-vitest-workspace/vitest.config.ts
+++ b/examples/app-vitest-workspace/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  // any global vitest config
+})

--- a/examples/app-vitest-workspace/vitest.workspace.ts
+++ b/examples/app-vitest-workspace/vitest.workspace.ts
@@ -1,0 +1,17 @@
+import { defineWorkspace } from 'vitest/config'
+import { defineVitestProject } from '@nuxt/test-utils/config'
+
+export default defineWorkspace([
+  await defineVitestProject({
+    test: {
+      name: 'nuxt',
+      include: ['**/*.nuxt.spec.ts'],
+    },
+  }),
+  {
+    test: {
+      name: 'unit',
+      include: ['**/*.unit.spec.ts'],
+    },
+  },
+])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,6 +355,31 @@ importers:
         specifier: 2.2.10
         version: 2.2.10(typescript@5.8.3)
 
+  examples/app-vitest-workspace:
+    dependencies:
+      nuxt:
+        specifier: ^3.16.2
+        version: 3.17.2(@parcel/watcher@2.5.1)(@types/node@22.15.12)(better-sqlite3@11.9.1)(db0@0.3.2(better-sqlite3@11.9.1))(encoding@0.1.13)(eslint@9.26.0(jiti@2.4.2))(idb-keyval@6.2.1)(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.2)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.12)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.1))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.7.1)
+    devDependencies:
+      '@nuxt/test-utils':
+        specifier: workspace:*
+        version: link:../..
+      globby:
+        specifier: 14.1.0
+        version: 14.1.0
+      happy-dom:
+        specifier: 17.4.4
+        version: 17.4.4
+      playwright-core:
+        specifier: 1.52.0
+        version: 1.52.0
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: 3.1.3
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.15.12)(@vitest/browser@3.1.3)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)(yaml@2.7.1)
+
   examples/content:
     devDependencies:
       '@nuxt/content':
@@ -4199,6 +4224,10 @@ packages:
 
   h3@1.15.3:
     resolution: {integrity: sha512-z6GknHqyX0h9aQaTx22VZDf6QyZn+0Nh+Ym8O/u0SGSkyF5cuTJYKlc8MkzW3Nzf9LE1ivcpmYC3FUGpywhuUQ==}
+
+  happy-dom@17.4.4:
+    resolution: {integrity: sha512-/Pb0ctk3HTZ5xEL3BZ0hK1AqDSAUuRQitOmROPHhfUYEWpmTImwfD8vFDGADmMAX0JYgbcgxWoLFKtsWhcpuVA==}
+    engines: {node: '>=18.0.0'}
 
   happy-dom@17.4.6:
     resolution: {integrity: sha512-OEV1hDe9i2rFr66+WZNiwy1S8rAJy6bRXmXql68YJDjdfHBRbN76om+qVh68vQACf6y5Bcr90e/oK53RQxsDdg==}
@@ -12395,6 +12424,11 @@ snapshots:
       ufo: 1.6.1
       uncrypto: 0.1.3
 
+  happy-dom@17.4.4:
+    dependencies:
+      webidl-conversions: 7.0.0
+      whatwg-mimetype: 3.0.0
+
   happy-dom@17.4.6:
     dependencies:
       webidl-conversions: 7.0.0
@@ -16552,6 +16586,49 @@ snapshots:
   vitest-environment-nuxt@1.0.1:
     dependencies:
       '@nuxt/test-utils': 'link:'
+
+  vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.12)(@vitest/browser@3.1.3)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)(yaml@2.7.1):
+    dependencies:
+      '@vitest/expect': 3.1.3
+      '@vitest/mocker': 3.1.3(vite@6.3.5(@types/node@22.15.12)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.1))
+      '@vitest/pretty-format': 3.1.3
+      '@vitest/runner': 3.1.3
+      '@vitest/snapshot': 3.1.3
+      '@vitest/spy': 3.1.3
+      '@vitest/utils': 3.1.3
+      chai: 5.2.0
+      debug: 4.4.0(supports-color@8.1.1)
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.13
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 6.3.5(@types/node@22.15.12)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.1)
+      vite-node: 3.1.3(@types/node@22.15.12)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 22.15.12
+      '@vitest/browser': 3.1.3(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.12)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.1))(vitest@3.1.3)
+      happy-dom: 17.4.4
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.12)(@vitest/browser@3.1.3)(happy-dom@17.4.6)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)(yaml@2.7.1):
     dependencies:

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import process from 'node:process'
 import type { Nuxt, NuxtConfig } from '@nuxt/schema'
 import type { UserWorkspaceConfig, InlineConfig as VitestConfig } from 'vitest/node'
 import { defineConfig } from 'vitest/config'
+import type { TestProjectInlineConfiguration } from 'vitest/config'
 import { setupDotenv } from 'c12'
 import type { DotenvOptions } from 'c12'
 import type { UserConfig as ViteUserConfig } from 'vite'
@@ -208,11 +209,15 @@ export async function getVitestConfigFromNuxt(
   return resolvedConfig
 }
 
-export async function defineVitestProject(config: UserWorkspaceConfig) {
+export async function defineVitestProject(config: TestProjectInlineConfiguration) {
   // When Nuxt module calls `startVitest`, we don't need to call `getVitestConfigFromNuxt` again
   if (process.env.__NUXT_VITEST_RESOLVED__) return config
 
-  return resolveConfig(config)
+  const resolvedConfig = await resolveConfig(config)
+
+  resolvedConfig.test.environment = 'nuxt'
+
+  return resolvedConfig
 }
 
 export function defineVitestConfig(config: ViteUserConfig & { test?: VitestConfig } = {}) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -243,7 +243,6 @@ export function defineVitestConfig(config: ViteUserConfig & { test?: VitestConfi
       resolvedConfig.test.workspace.push({
         extends: true,
         test: {
-          browser: undefined,
           name: 'nuxt',
           environment: 'nuxt',
           include: [

--- a/src/config.ts
+++ b/src/config.ts
@@ -243,9 +243,7 @@ export function defineVitestConfig(config: ViteUserConfig & { test?: VitestConfi
       resolvedConfig.test.workspace.push({
         extends: true,
         test: {
-          browser: {
-            enabled: false,
-          },
+          browser: undefined,
           name: 'nuxt',
           environment: 'nuxt',
           include: [

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,13 +1,13 @@
 import process from 'node:process'
 import type { Nuxt, NuxtConfig } from '@nuxt/schema'
-import type { InlineConfig as VitestConfig } from 'vitest/node'
-import { defaultExclude, defaultInclude, defineConfig } from 'vitest/config'
+import type { UserWorkspaceConfig, InlineConfig as VitestConfig } from 'vitest/node'
+import { defineConfig } from 'vitest/config'
 import { setupDotenv } from 'c12'
 import type { DotenvOptions } from 'c12'
 import type { UserConfig as ViteUserConfig } from 'vite'
 import type { DateString } from 'compatx'
 import { defu } from 'defu'
-import { createResolver, findPath } from '@nuxt/kit'
+import { loadNuxt, buildNuxt, createResolver, findPath } from '@nuxt/kit'
 
 import { applyEnv } from './utils'
 
@@ -22,11 +22,7 @@ interface LoadNuxtOptions {
 }
 
 // https://github.com/nuxt/framework/issues/6496
-async function startNuxtAndGetViteConfig(
-  rootDir = process.cwd(),
-  options: LoadNuxtOptions = {},
-) {
-  const { loadNuxt, buildNuxt } = await import('@nuxt/kit')
+async function startNuxtAndGetViteConfig(rootDir = process.cwd(), options: LoadNuxtOptions = {}) {
   const nuxt = await loadNuxt({
     cwd: rootDir,
     dev: false,
@@ -151,6 +147,7 @@ export async function getVitestConfigFromNuxt(
       server: { middlewareMode: false },
       plugins: [
         {
+          // TODO: prefix with 'nuxt:test-utils:' in next major version
           name: 'disable-auto-execute',
           enforce: 'pre',
           transform(code, id) {
@@ -159,6 +156,17 @@ export async function getVitestConfigFromNuxt(
                 /(?<!vueAppPromise = )entry\(\)/,
                 'Promise.resolve()',
               )
+            }
+          },
+        },
+        {
+          name: 'nuxt:test-utils:browser-conditions',
+          enforce: 'pre',
+          config() {
+            return {
+              resolve: {
+                conditions: ['web', 'import', 'module', 'default'],
+              },
             }
           },
         },
@@ -200,64 +208,68 @@ export async function getVitestConfigFromNuxt(
   return resolvedConfig
 }
 
+export async function defineVitestProject(config: UserWorkspaceConfig) {
+  // When Nuxt module calls `startVitest`, we don't need to call `getVitestConfigFromNuxt` again
+  if (process.env.__NUXT_VITEST_RESOLVED__) return config
+
+  return resolveConfig(config)
+}
+
 export function defineVitestConfig(config: ViteUserConfig & { test?: VitestConfig } = {}) {
   return defineConfig(async () => {
     // When Nuxt module calls `startVitest`, we don't need to call `getVitestConfigFromNuxt` again
     if (process.env.__NUXT_VITEST_RESOLVED__) return config
 
-    const overrides = config.test?.environmentOptions?.nuxt?.overrides || {}
-    overrides.rootDir = config.test?.environmentOptions?.nuxt?.rootDir
+    const resolvedConfig = await resolveConfig(config)
 
-    if (config.test?.setupFiles && !Array.isArray(config.test.setupFiles)) {
-      config.test.setupFiles = [config.test.setupFiles].filter(Boolean) as string[]
+    if (resolvedConfig.test.browser?.enabled) {
+      return resolvedConfig
     }
 
-    const resolvedConfig = defu(
-      config satisfies ViteUserConfig & { test?: VitestConfig },
-      await getVitestConfigFromNuxt(undefined, {
-        dotenv: config.test?.environmentOptions?.nuxt?.dotenv,
-        overrides: structuredClone(overrides),
-      }) satisfies ViteUserConfig & { test: VitestConfig },
-    ) as ViteUserConfig & { test: VitestConfig }
+    if ('workspace' in resolvedConfig.test) {
+      throw new Error(
+        'The `workspace` option is not supported with `defineVitestConfig`. Instead, use `defineVitestProject` to define each workspace project that uses the Nuxt environment.',
+      )
+    }
 
     const defaultEnvironment = resolvedConfig.test.environment || 'node'
     if (defaultEnvironment !== 'nuxt') {
-      if (!resolvedConfig.test.workspace) {
-        resolvedConfig.test.workspace = []
-        resolvedConfig.test.workspace.push({
-          extends: true,
-          test: {
-            name: 'nuxt',
-            environment: 'nuxt',
-            include: [
-              '**/*.nuxt.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
-              '{test,tests}/nuxt/**.*',
-            ],
+      resolvedConfig.test.workspace = []
+      resolvedConfig.test.workspace.push({
+        extends: true,
+        test: {
+          browser: {
+            enabled: false,
           },
-        })
-      }
-
-      if (typeof resolvedConfig.test.workspace !== 'string') {
-        resolvedConfig.test.workspace ||= []
-        resolvedConfig.test.workspace.push(
-          {
-            test: {
-              name: defaultEnvironment,
-              environment: defaultEnvironment,
-              include: defaultInclude,
-              exclude: [
-                ...defaultExclude,
-                '**/*.nuxt.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
-                '{test,tests}/nuxt/**.*',
-              ],
-            },
-          },
-        )
-      }
+          name: 'nuxt',
+          environment: 'nuxt',
+          include: [
+            '**/*.nuxt.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+            '{test,tests}/nuxt/**.*',
+          ],
+        },
+      })
     }
 
     return resolvedConfig
   })
+}
+
+async function resolveConfig<T extends ViteUserConfig & { test?: VitestConfig } | UserWorkspaceConfig>(config: T) {
+  const overrides = config.test?.environmentOptions?.nuxt?.overrides || {}
+  overrides.rootDir = config.test?.environmentOptions?.nuxt?.rootDir
+
+  if (config.test?.setupFiles && !Array.isArray(config.test.setupFiles)) {
+    config.test.setupFiles = [config.test.setupFiles].filter(Boolean) as string[]
+  }
+
+  return defu(
+    config satisfies T,
+    await getVitestConfigFromNuxt(undefined, {
+      dotenv: config.test?.environmentOptions?.nuxt?.dotenv,
+      overrides: structuredClone(overrides),
+    }) satisfies ViteUserConfig & { test: NonNullable<T['test']> },
+  ) as T & { test: NonNullable<T['test']> }
 }
 
 interface NuxtEnvironmentOptions {

--- a/src/module.ts
+++ b/src/module.ts
@@ -93,6 +93,13 @@ export default defineNuxtModule<NuxtVitestOptions>({
         return !p || !('name' in p) || !vitePluginBlocklist.includes(p.name)
       })
 
+      // TODO: investigate why this is needed
+      viteConfig.test.environmentMatchGlobs ||= []
+      viteConfig.test.environmentMatchGlobs.push(
+        ['**/*.nuxt.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}', 'nuxt'],
+        ['{test,tests}/nuxt/**.*', 'nuxt'],
+      )
+
       process.env.__NUXT_VITEST_RESOLVED__ = 'true'
       const { startVitest } = (await import(pathToFileURL(await resolvePath('vitest/node')).href)) as typeof import('vitest/node')
 


### PR DESCRIPTION
### 🔗 Linked issue

closes https://github.com/nuxt/test-utils/pull/1124
resolves https://github.com/nuxt/test-utils/issues/1123

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this is the beginning of moving to vitest workspaces

- [x] remove `environmentMatchGlobs` usage
- [ ] investigate why `workspaces` are not working with programmatic `startVitest` usage (cc: @antfu)
- [x] move more configuration into the workspace config to avoid 'leakage'
