### PR TITLE
fix: Include tests without `.nuxt.` extension

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import process from 'node:process'
 import type { Nuxt, NuxtConfig } from '@nuxt/schema'
 import type { UserWorkspaceConfig, InlineConfig as VitestConfig } from 'vitest/node'
-import { defineConfig } from 'vitest/config'
+import { defineConfig, defaultExclude } from 'vitest/config'
 import type { TestProjectInlineConfiguration } from 'vitest/config'
 import { setupDotenv } from 'c12'
 import type { DotenvOptions } from 'c12'
@@ -261,6 +261,18 @@ export function defineVitestConfig(config: ViteUserConfig & { test?: VitestConfi
           include: [
             '**/*.nuxt.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
             '{test,tests}/nuxt/**.*',
+          ],
+        },
+      })
+      resolvedConfig.test.workspace.push({
+        extends: true,
+        test: {
+          name: defaultEnvironment,
+          environment: defaultEnvironment,
+          exclude: [
+            ...defaultExclude,
+            './**/*.nuxt.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+            './{test,tests}/nuxt/**.*',
           ],
         },
       })


### PR DESCRIPTION
Include tests without `.nuxt.` extension, by creating a workspace for the default environment

### 🔗 Linked issue

Resolves #1296

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Moving environmentMatchGlobs to define a workspace for the nuxt environment resulted in Vitest only running tests within that specific nuxt workspace, excluding tests from the parent/default configuration (from which the workspace inherits). Creating an additional workspace for the default, non-Nuxt environment ensured all tests were included again.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
