### PR TITLE
test: add failing test for stubbed global provide

### DIFF
--- a/examples/app-vitest-full/tests/nuxt/injected-value-component.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/injected-value-component.spec.ts
@@ -28,11 +28,11 @@ describe('InjectedValueComponent', () => {
       expect(inject(CUSTOM_VUE_PLUGIN_SYMBOL2)).toBe(VUE_INJECTED_VALUE2)
     })
   })
-  it('can stub injected values', async () => {
+  it.fails('can stub injected values', async () => {
     const component = await mountSuspended(InjectedValueComponent, {
       global: {
         provide: {
-          [VUE_INJECTED_VALUE]: 'stubbed value',
+          [CUSTOM_VUE_PLUGIN_SYMBOL]: 'stubbed value',
         },
       },
     })


### PR DESCRIPTION
> [!CAUTION]
> This PR should only serve as a reproduction for an issue I encountered with the API, but it's not fixing the issue and should not be merged as-is. 

I think this is a reproduction for the case reported in #750, #1206, and #1102 (or some of them).

The main question this PR should answer is: How are we supposed to stub the value of a globally provided value?

In my experience, I could make it work by passing a `provide` property directly to the `renderWithNuxt` method (forcing the types), but it is inconsistent with the API used by tools like Vue Test Utils.

## Failing test

https://github.com/nuxt/test-utils/actions/runs/15411633006/job/43364731048?pr=1314

## Screensots

<img width="1022" alt="image" src="https://github.com/user-attachments/assets/70e1048a-3d35-434e-9f30-aeb924b4ba22" />
