### PR TITLE
fix(mocks): add missing mocks to vue-devtools

### DIFF
--- a/src/runtime/mocks/vue-devtools.ts
+++ b/src/runtime/mocks/vue-devtools.ts
@@ -4,3 +4,9 @@ export function createRpcServer() {}
 export const devtools = {
   init() {},
 }
+export function addCustomCommand() {}
+export function addCustomTab() {}
+export function onDevToolsClientConnected() {}
+export function onDevToolsConnected() {}
+export function removeCustomCommand() {}
+export function setupDevToolsPlugin() {


### PR DESCRIPTION
### 🔗 Linked issue
Resolves: https://github.com/nuxt/test-utils/issues/1320
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In my project I've recently experience an error while running Vitest tests which reported that these exports are missing, after patching it everything worked just fine.

My guess is that the vue-devtools got some new features but these mocks were not brought up to date.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
