### PR TITLE
chore: fix URL must be file:// protocol error in e2e tests

### DIFF
--- a/examples/app-bun/package.json
+++ b/examples/app-bun/package.json
@@ -11,7 +11,7 @@
     "test": "bun test"
   },
   "dependencies": {
-    "nuxt": "^3.17.5"
+    "nuxt": "catalog:"
   },
   "devDependencies": {
     "@nuxt/test-utils": "latest",

--- a/examples/app-bun/test/browser.e2e.spec.ts
+++ b/examples/app-bun/test/browser.e2e.spec.ts
@@ -1,10 +1,10 @@
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { describe, it, expect } from 'bun:test'
 import { createPage, setup } from '@nuxt/test-utils/e2e'
 import { isWindows } from 'std-env'
 
 await setup({
-  rootDir: fileURLToPath(new URL('../', import.meta.url)),
+  rootDir: resolve('../', import.meta.dirname),
   browser: true,
 })
 

--- a/examples/app-bun/test/dev.e2e.spec.ts
+++ b/examples/app-bun/test/dev.e2e.spec.ts
@@ -1,9 +1,9 @@
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { describe, it, expect } from 'bun:test'
 import { $fetch, setup } from '@nuxt/test-utils/e2e'
 
 await setup({
-  rootDir: fileURLToPath(new URL('../', import.meta.url)),
+  rootDir: resolve('../', import.meta.dirname),
   dev: true,
 })
 

--- a/examples/app-bun/test/server.e2e.spec.ts
+++ b/examples/app-bun/test/server.e2e.spec.ts
@@ -1,9 +1,10 @@
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { describe, it, expect } from 'bun:test'
 import { $fetch, setup } from '@nuxt/test-utils/e2e'
 
 await setup({
-  rootDir: fileURLToPath(new URL('../', import.meta.url)),
+  rootDir: resolve('../', import.meta.dirname),
+  server: true,
 })
 
 describe('app', () => {

--- a/examples/app-cucumber/package.json
+++ b/examples/app-cucumber/package.json
@@ -11,7 +11,7 @@
     "test": "NODE_OPTIONS='--loader ts-node/esm' NODE_ENV=test cucumber-js"
   },
   "dependencies": {
-    "nuxt": "^3.17.5"
+    "nuxt": "catalog:"
   },
   "devDependencies": {
     "@cucumber/cucumber": "11.3.0",

--- a/examples/app-jest/package.json
+++ b/examples/app-jest/package.json
@@ -11,7 +11,7 @@
     "test": "node --no-warnings --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "dependencies": {
-    "nuxt": "^3.17.5"
+    "nuxt": "catalog:"
   },
   "devDependencies": {
     "@nuxt/test-utils": "latest",

--- a/examples/app-jest/test/browser.e2e.spec.ts
+++ b/examples/app-jest/test/browser.e2e.spec.ts
@@ -1,9 +1,9 @@
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { createPage, setup } from '@nuxt/test-utils/e2e'
 import { isWindows } from 'std-env'
 
 await setup({
-  rootDir: fileURLToPath(new URL('../', import.meta.url)),
+  rootDir: resolve('../', import.meta.dirname),
   browser: true,
 })
 

--- a/examples/app-jest/test/dev.e2e.spec.ts
+++ b/examples/app-jest/test/dev.e2e.spec.ts
@@ -1,8 +1,8 @@
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { $fetch, setup } from '@nuxt/test-utils/e2e'
 
 await setup({
-  rootDir: fileURLToPath(new URL('../', import.meta.url)),
+  rootDir: resolve('../', import.meta.dirname),
   dev: true,
 })
 

--- a/examples/app-jest/test/server.e2e.spec.ts
+++ b/examples/app-jest/test/server.e2e.spec.ts
@@ -1,8 +1,9 @@
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { $fetch, setup } from '@nuxt/test-utils/e2e'
 
 await setup({
-  rootDir: fileURLToPath(new URL('../', import.meta.url)),
+  rootDir: resolve('../', import.meta.dirname),
+  server: true,
 })
 
 describe('app', () => {

--- a/examples/app-playwright/package.json
+++ b/examples/app-playwright/package.json
@@ -11,7 +11,7 @@
     "test": "playwright test"
   },
   "dependencies": {
-    "nuxt": "^3.17.5"
+    "nuxt": "catalog:"
   },
   "devDependencies": {
     "@nuxt/test-utils": "latest",

--- a/examples/app-vitest-browser/package.json
+++ b/examples/app-vitest-browser/package.json
@@ -14,7 +14,7 @@
     "@nuxt/test-utils": "latest",
     "@vitest/browser": "3.2.3",
     "@vue/test-utils": "2.4.6",
-    "nuxt": "3.17.5",
+    "nuxt": "catalog:",
     "typescript": "5.8.3",
     "vitest": "3.2.3",
     "vitest-browser-vue": "0.2.0"

--- a/examples/app-vitest-full/package.json
+++ b/examples/app-vitest-full/package.json
@@ -21,7 +21,7 @@
     "happy-dom": "18.0.1",
     "jsdom": "26.1.0",
     "listhen": "1.9.0",
-    "nuxt": "3.17.5",
+    "nuxt": "catalog:",
     "typescript": "5.8.3",
     "vitest": "3.2.3",
     "vue-tsc": "2.2.10"

--- a/examples/app-vitest-workspace/package.json
+++ b/examples/app-vitest-workspace/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "nuxt": "^3.17.5"
+    "nuxt": "catalog:"
   },
   "devDependencies": {
     "@nuxt/test-utils": "latest",

--- a/examples/app-vitest/package.json
+++ b/examples/app-vitest/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "nuxt": "^3.17.5"
+    "nuxt": "catalog:"
   },
   "devDependencies": {
     "@nuxt/test-utils": "latest",

--- a/examples/app-vitest/test/browser.e2e.spec.ts
+++ b/examples/app-vitest/test/browser.e2e.spec.ts
@@ -1,10 +1,10 @@
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { createPage, setup } from '@nuxt/test-utils/e2e'
 import { describe, expect, it } from 'vitest'
 import { isWindows } from 'std-env'
 
 await setup({
-  rootDir: fileURLToPath(new URL('../', import.meta.url)),
+  rootDir: resolve('../', import.meta.dirname),
   browser: true,
   setupTimeout: isWindows ? 240000 : 120000,
 })

--- a/examples/app-vitest/test/build-false.e2e.spec.ts
+++ b/examples/app-vitest/test/build-false.e2e.spec.ts
@@ -1,10 +1,9 @@
-import { fileURLToPath } from 'node:url'
 import { resolve } from 'node:path'
 import { $fetch, setup } from '@nuxt/test-utils/e2e'
 import { describe, expect, it } from 'vitest'
 import { loadNuxt, buildNuxt } from '@nuxt/kit'
 
-const rootDir = fileURLToPath(new URL('../', import.meta.url))
+const rootDir = resolve('../', import.meta.dirname)
 const randomId = Math.random().toString(36).slice(2, 8)
 const buildDir = resolve(rootDir, '.nuxt', 'test', randomId)
 const buildOutput = resolve(buildDir, 'output')

--- a/examples/app-vitest/test/dev.e2e.spec.ts
+++ b/examples/app-vitest/test/dev.e2e.spec.ts
@@ -1,9 +1,9 @@
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { $fetch, setup } from '@nuxt/test-utils/e2e'
 import { describe, expect, it } from 'vitest'
 
 await setup({
-  rootDir: fileURLToPath(new URL('../', import.meta.url)),
+  rootDir: resolve('../', import.meta.dirname),
   dev: true,
 })
 

--- a/examples/app-vitest/test/generate.e2e.spec.ts
+++ b/examples/app-vitest/test/generate.e2e.spec.ts
@@ -1,11 +1,10 @@
-import { fileURLToPath } from 'node:url'
-import { resolve } from 'pathe'
+import { resolve } from 'node:path'
 import { glob } from 'tinyglobby'
 import { setup, useTestContext } from '@nuxt/test-utils/e2e'
 import { describe, expect, it } from 'vitest'
 
 await setup({
-  rootDir: fileURLToPath(new URL('../', import.meta.url)),
+  rootDir: resolve('../', import.meta.dirname),
   nuxtConfig: {
     nitro: {
       prerender: {

--- a/examples/content/package.json
+++ b/examples/content/package.json
@@ -16,7 +16,7 @@
     "@nuxt/content": "3.5.1",
     "@nuxt/test-utils": "latest",
     "@vitest/browser": "3.2.3",
-    "nuxt": "3.17.5",
+    "nuxt": "catalog:",
     "vitest": "3.2.3",
     "vitest-browser-vue": "0.2.0"
   }

--- a/examples/i18n/package.json
+++ b/examples/i18n/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@nuxt/test-utils": "latest",
     "@nuxtjs/i18n": "9.5.4",
-    "nuxt": "3.17.5",
+    "nuxt": "catalog:",
     "vitest": "3.2.3"
   }
 }

--- a/examples/module/package.json
+++ b/examples/module/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@nuxt/module-builder": "1.0.1",
     "@nuxt/test-utils": "latest",
-    "nuxt": "3.17.5",
+    "nuxt": "catalog:",
     "vitest": "3.2.3"
   }
 }

--- a/examples/module/playground/package.json
+++ b/examples/module/playground/package.json
@@ -8,7 +8,7 @@
     "generate": "nuxi generate"
   },
   "devDependencies": {
-    "nuxt": "3.17.5"
+    "nuxt": "catalog:"
   },
   "dependencies": {
     "vue": "^3.5.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    nuxt:
+      specifier: 3.17.5
+      version: 3.17.5
+
 overrides:
   '@cucumber/cucumber': 11.3.0
   '@nuxt/kit': ^3.17.5
@@ -195,7 +201,7 @@ importers:
   examples/app-bun:
     dependencies:
       nuxt:
-        specifier: ^3.17.5
+        specifier: 'catalog:'
         version: 3.17.5(@parcel/watcher@2.5.1)(@types/node@22.15.21)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.27.0(jiti@2.4.2))(idb-keyval@6.2.2)(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0)
     devDependencies:
       '@nuxt/test-utils':
@@ -214,7 +220,7 @@ importers:
   examples/app-cucumber:
     dependencies:
       nuxt:
-        specifier: ^3.17.5
+        specifier: 'catalog:'
         version: 3.17.5(@parcel/watcher@2.5.1)(@types/node@22.15.21)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.27.0(jiti@2.4.2))(idb-keyval@6.2.2)(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0)
     devDependencies:
       '@cucumber/cucumber':
@@ -230,7 +236,7 @@ importers:
   examples/app-jest:
     dependencies:
       nuxt:
-        specifier: ^3.17.5
+        specifier: 'catalog:'
         version: 3.17.5(@parcel/watcher@2.5.1)(@types/node@22.15.21)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.27.0(jiti@2.4.2))(idb-keyval@6.2.2)(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0)
     devDependencies:
       '@nuxt/test-utils':
@@ -258,7 +264,7 @@ importers:
   examples/app-playwright:
     dependencies:
       nuxt:
-        specifier: ^3.17.5
+        specifier: 'catalog:'
         version: 3.17.5(@parcel/watcher@2.5.1)(@types/node@22.15.21)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.27.0(jiti@2.4.2))(idb-keyval@6.2.2)(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0)
     devDependencies:
       '@nuxt/test-utils':
@@ -274,7 +280,7 @@ importers:
   examples/app-vitest:
     dependencies:
       nuxt:
-        specifier: ^3.17.5
+        specifier: 'catalog:'
         version: 3.17.5(@parcel/watcher@2.5.1)(@types/node@22.15.21)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.27.0(jiti@2.4.2))(idb-keyval@6.2.2)(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0)
     devDependencies:
       '@nuxt/test-utils':
@@ -308,7 +314,7 @@ importers:
         specifier: 2.4.6
         version: 2.4.6
       nuxt:
-        specifier: 3.17.5
+        specifier: 'catalog:'
         version: 3.17.5(@parcel/watcher@2.5.1)(@types/node@22.15.21)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.27.0(jiti@2.4.2))(idb-keyval@6.2.2)(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0)
       typescript:
         specifier: 5.8.3
@@ -342,7 +348,7 @@ importers:
         specifier: 1.9.0
         version: 1.9.0
       nuxt:
-        specifier: 3.17.5
+        specifier: 'catalog:'
         version: 3.17.5(@parcel/watcher@2.5.1)(@types/node@22.15.21)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.27.0(jiti@2.4.2))(idb-keyval@6.2.2)(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0)
       typescript:
         specifier: 5.8.3
@@ -357,7 +363,7 @@ importers:
   examples/app-vitest-workspace:
     dependencies:
       nuxt:
-        specifier: ^3.17.5
+        specifier: 'catalog:'
         version: 3.17.5(@parcel/watcher@2.5.1)(@types/node@22.15.21)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.27.0(jiti@2.4.2))(idb-keyval@6.2.2)(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0)
     devDependencies:
       '@nuxt/test-utils':
@@ -391,7 +397,7 @@ importers:
         specifier: 3.2.3
         version: 3.2.3(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0))(vitest@3.2.3)
       nuxt:
-        specifier: 3.17.5
+        specifier: 'catalog:'
         version: 3.17.5(@parcel/watcher@2.5.1)(@types/node@22.15.21)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.27.0(jiti@2.4.2))(idb-keyval@6.2.2)(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0)
       vitest:
         specifier: 3.2.3
@@ -409,7 +415,7 @@ importers:
         specifier: 9.5.4
         version: 9.5.4(@vue/compiler-dom@3.5.16)(eslint@9.27.0(jiti@2.4.2))(magicast@0.3.5)(rollup@4.41.1)(vue@3.5.16(typescript@5.8.3))
       nuxt:
-        specifier: 3.17.5
+        specifier: 'catalog:'
         version: 3.17.5(@parcel/watcher@2.5.1)(@types/node@22.15.21)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.27.0(jiti@2.4.2))(idb-keyval@6.2.2)(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0)
       vitest:
         specifier: 3.2.3
@@ -428,7 +434,7 @@ importers:
         specifier: workspace:*
         version: link:../..
       nuxt:
-        specifier: 3.17.5
+        specifier: 'catalog:'
         version: 3.17.5(@parcel/watcher@2.5.1)(@types/node@22.15.21)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.27.0(jiti@2.4.2))(idb-keyval@6.2.2)(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0)
       vitest:
         specifier: 3.2.3
@@ -444,7 +450,7 @@ importers:
         version: 4.5.1(vue@3.5.16(typescript@5.8.3))
     devDependencies:
       nuxt:
-        specifier: 3.17.5
+        specifier: 'catalog:'
         version: 3.17.5(@parcel/watcher@2.5.1)(@types/node@22.15.21)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.27.0(jiti@2.4.2))(idb-keyval@6.2.2)(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0)
 
   stubs/vitest-environment-nuxt:
@@ -9374,7 +9380,7 @@ snapshots:
 
   '@oxc-parser/binding-wasm32-wasi@0.72.2':
     dependencies:
-      '@napi-rs/wasm-runtime': 0.2.10
+      '@napi-rs/wasm-runtime': 0.2.11
     optional: true
 
   '@oxc-parser/binding-win32-arm64-msvc@0.61.2':
@@ -10303,7 +10309,7 @@ snapshots:
       '@babel/core': 7.27.4
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/parser': 7.27.4
+      '@babel/parser': 7.27.5
       '@vue/compiler-sfc': 3.5.16
     transitivePeerDependencies:
       - supports-color
@@ -12546,7 +12552,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.27.4
-      '@babel/parser': 7.27.4
+      '@babel/parser': 7.27.5
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,5 @@ packages:
   - "examples/*"
   - "examples/module/playground"
   - "stubs/*"
+catalog:
+  nuxt: "3.17.5"

--- a/stubs/vitest-environment-nuxt/package.json
+++ b/stubs/vitest-environment-nuxt/package.json
@@ -8,6 +8,6 @@
     "./utils": "./utils.mjs"
   },
   "dependencies": {
-    "@nuxt/test-utils": ">=3.15.1"
+    "@nuxt/test-utils": ">=3.15.3"
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I couldn't run the E2E Example tests because the configs use `fileURLToPath` without a `file://` protocol.  It's just trying to resolve the rootDir up a directory, so this PR swaps to using `resolve`

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
