### PR TITLE
fix(module): use user `vite` version to merge config

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -16,6 +16,7 @@ export default defineBuildConfig({
   ],
   externals: [
     '#dirs',
+    'vite',
     'bun:test',
     '#app/entry',
     '#build/root-component.mjs',

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "tinyexec": "^1.0.1",
     "ufo": "^1.6.1",
     "unplugin": "^2.3.5",
-    "vite": "^6.3.5",
     "vitest-environment-nuxt": "^1.0.1",
     "vue": "^3.5.17"
   },
@@ -119,6 +118,7 @@
     "typescript": "5.8.3",
     "unbuild": "latest",
     "unimport": "5.1.0",
+    "vite": "6.3.5",
     "vitest": "3.2.4",
     "vue-router": "4.5.1",
     "vue-tsc": "2.2.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,9 +92,6 @@ importers:
       unplugin:
         specifier: ^2.3.5
         version: 2.3.5
-      vite:
-        specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.15.34)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0)
       vitest-environment-nuxt:
         specifier: ^1.0.1
         version: 1.0.1
@@ -183,6 +180,9 @@ importers:
       unimport:
         specifier: 5.1.0
         version: 5.1.0
+      vite:
+        specifier: ^6.3.5
+        version: 6.3.5(@types/node@22.15.34)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0)
       vitest:
         specifier: 3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.34)(@vitest/browser@3.2.4)(happy-dom@18.0.1)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.40.0)(yaml@2.8.0)
@@ -3935,9 +3935,6 @@ packages:
   expect@30.0.3:
     resolution: {integrity: sha512-HXg6NvK35/cSYZCUKAtmlgCFyqKM4frEPbzrav5hRqb0GMz0E0lS5hfzYjSaiaE5ysnp/qI2aeZkeyeIAOeXzQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  exsolve@1.0.5:
-    resolution: {integrity: sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg==}
 
   exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
@@ -9031,7 +9028,7 @@ snapshots:
       defu: 6.1.4
       destr: 2.0.5
       errx: 0.1.0
-      exsolve: 1.0.5
+      exsolve: 1.0.7
       ignore: 7.0.5
       jiti: 2.4.2
       klona: 2.0.6
@@ -9111,7 +9108,7 @@ snapshots:
       defu: 6.1.4
       esbuild: 0.25.5
       escape-string-regexp: 5.0.0
-      exsolve: 1.0.5
+      exsolve: 1.0.7
       externality: 1.0.2
       get-port-please: 3.1.2
       h3: 1.15.3
@@ -10731,7 +10728,7 @@ snapshots:
       confbox: 0.2.2
       defu: 6.1.4
       dotenv: 16.5.0
-      exsolve: 1.0.5
+      exsolve: 1.0.7
       giget: 2.0.0
       jiti: 2.4.2
       ohash: 2.0.11
@@ -11713,8 +11710,6 @@ snapshots:
       jest-mock: 30.0.2
       jest-util: 30.0.2
 
-  exsolve@1.0.5: {}
-
   exsolve@1.0.7: {}
 
   extend@3.0.2: {}
@@ -12271,7 +12266,7 @@ snapshots:
 
   impound@1.0.0:
     dependencies:
-      exsolve: 1.0.5
+      exsolve: 1.0.7
       mocked-exports: 0.1.1
       pathe: 2.0.3
       unplugin: 2.3.5
@@ -13686,7 +13681,7 @@ snapshots:
       esbuild: 0.25.5
       escape-string-regexp: 5.0.0
       etag: 1.8.1
-      exsolve: 1.0.5
+      exsolve: 1.0.7
       globby: 14.1.0
       gzip-size: 7.0.0
       h3: 1.15.3
@@ -13981,7 +13976,7 @@ snapshots:
       esbuild: 0.25.5
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
-      exsolve: 1.0.5
+      exsolve: 1.0.7
       h3: 1.15.3
       hookable: 5.5.3
       ignore: 7.0.5
@@ -14379,7 +14374,7 @@ snapshots:
   pkg-types@2.1.0:
     dependencies:
       confbox: 0.2.2
-      exsolve: 1.0.5
+      exsolve: 1.0.7
       pathe: 2.0.3
 
   pkg-types@2.1.1:
@@ -15682,7 +15677,7 @@ snapshots:
   unenv@2.0.0-rc.17:
     dependencies:
       defu: 6.1.4
-      exsolve: 1.0.5
+      exsolve: 1.0.7
       ohash: 2.0.11
       pathe: 2.0.3
       ufo: 1.6.1
@@ -16020,7 +16015,7 @@ snapshots:
   vite-plugin-vue-tracer@0.1.3(vite@6.3.5(@types/node@22.15.34)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3)):
     dependencies:
       estree-walker: 3.0.3
-      exsolve: 1.0.5
+      exsolve: 1.0.7
       magic-string: 0.30.17
       pathe: 2.0.3
       source-map-js: 1.2.1

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,11 +1,10 @@
 /// <reference types="@nuxt/devtools-kit" />
 
 import { pathToFileURL } from 'node:url'
-import { addVitePlugin, createResolver, defineNuxtModule, logger, resolvePath } from '@nuxt/kit'
+import { addVitePlugin, createResolver, defineNuxtModule, logger, resolvePath, importModule } from '@nuxt/kit'
 import type { Vitest, UserConfig as VitestConfig } from 'vitest/node'
 import type { Reporter } from 'vitest/reporters'
 import type { RunnerTestFile } from 'vitest'
-import { mergeConfig } from 'vite'
 import type { InlineConfig as ViteConfig } from 'vite'
 import { getPort } from 'get-port-please'
 import { h } from 'vue'
@@ -85,6 +84,7 @@ export default defineNuxtModule<NuxtVitestOptions>({
     let URL: string
 
     async function start() {
+      const { mergeConfig } = await importModule<typeof import('vite')>('vite', { paths: nuxt.options.modulesDir })
       const rawViteConfig = mergeConfig({}, await rawViteConfigPromise)
 
       const viteConfig = await getVitestConfigFromNuxt({ nuxt, viteConfig: defu({ test: options.vitestConfig }, rawViteConfig) })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently test/utils has an explicit dependency on vite, as we need to respect the algo for merging vite configuration. But that does unduly bind a particular version of ntu to a certain version of vite (and therefore, perhaps, nuxt).

with the upcoming update to vite v7, this seems an appropriate time to import vite dynamically as-needed, respecting the version of the package that an end user has installed.