### PR TITLE
Add missing import getCurrentInstance from vue

### DIFF
--- a/src/runtime-utils/render.ts
+++ b/src/runtime-utils/render.ts
@@ -1,4 +1,4 @@
-import { Suspense, effectScope, h, nextTick, isReadonly, reactive, unref, defineComponent } from 'vue'
+import { Suspense, effectScope, h, nextTick, isReadonly, reactive, unref, defineComponent, getCurrentInstance } from 'vue'
 import type { ComponentInternalInstance, DefineComponent, SetupContext } from 'vue'
 import type { RenderOptions as TestingLibraryRenderOptions } from '@testing-library/vue'
 import { defu } from 'defu'


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1371 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds the missing import for `getCurrentInstance()` from vue in `render.ts`. Fixes the ReferenceError in build output.

Build output before
```
import { reactive, h as h$1, Suspense, nextTick, unref, isReadonly, getCurrentInstance as getCurrentInstance$1, defineComponent as defineComponent$1, effectScope } from 'vue';
```

Build output after
```
import { reactive, h as h$1, Suspense, nextTick, unref, isReadonly, getCurrentInstance, defineComponent as defineComponent$1, effectScope } from 'vue';
```

