### PR TITLE
docs(types): use jsdoc standard `@default` formatting

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -348,7 +348,7 @@ export interface NuxtEnvironmentOptions {
   rootDir?: string
   /**
    * The starting URL for your Nuxt window environment
-   * @default {http://localhost:3000}
+   * @default 'http://localhost:3000'
    */
   url?: string
   /**
@@ -361,14 +361,14 @@ export interface NuxtEnvironmentOptions {
   overrides?: NuxtConfig
   /**
    * The id of the root div to which the app should be mounted. You should also set `app.rootId` to the same value.
-   * @default {nuxt-test}
+   * @default 'nuxt-test'
    */
   rootId?: string
   /**
    * The name of the DOM environment to use.
    *
    * It also needs to be installed as a dev dependency in your project.
-   * @default {happy-dom}
+   * @default 'happy-dom'
    */
   domEnvironment?: 'happy-dom' | 'jsdom'
 

--- a/src/e2e/types.ts
+++ b/src/e2e/types.ts
@@ -10,41 +10,41 @@ export interface TestOptions {
   fixture: string
   /**
    * Name of the configuration file.
-   * @default `'nuxt.config`
+   * @default 'nuxt.config'
    */
   configFile: string
   /**
    * Path to a directory with a Nuxt app to be put under test.
-   * @default `'.'`
+   * @default '.'
    */
   rootDir: string
   buildDir: string
   nuxtConfig: NuxtConfig
   /**
    * Whether to run a separate build step.
-   * @default `true` (`false` if `browser` or `server` is disabled, or if a `host` is provided)
+   * @default true // (`false` if `browser` or `server` is disabled, or if a `host` is provided)
    */
   build: boolean
   dev: boolean
   /**
    * The amount of time (in milliseconds) to allow for `setupTest` to complete its work (which could include building or generating files for a Nuxt application, depending on the options that are passed).
-   * @default `120000` or `240000` on windows
+   * @default 120000 // or `240000` on windows
    */
   setupTimeout: number
   /**
    * The amount of time (in milliseconds) to allow tearing down the test environment, such as closing the browser.
-   * @default `30000`
+   * @default 30000
    */
   teardownTimeout: number
   waitFor: number
   /**
    * Under the hood, Nuxt test utils uses [`playwright`](https://playwright.dev) to carry out browser testing. If this option is set, a browser will be launched and can be controlled in the subsequent test suite.
-   * @default `false`
+   * @default false
    */
   browser: boolean
   /**
    * Specify the runner for the test suite. One of `'vitest' | 'jest' | 'cucumber' | 'bun'`.
-   * @default `vitest`
+   * @default 'vitest'
    */
   runner: TestRunner
   logLevel: number
@@ -56,17 +56,17 @@ export interface TestOptions {
   }
   /**
    * Whether to launch a server to respond to requests in the test suite.
-   * @default `true` (`false` if a `host` is provided)
+   * @default true // (`false` if a `host` is provided)
    */
   server: boolean
   /**
    * If provided, a URL to use as the test target instead of building and running a new server. Useful for running "real" end-to-end tests against a deployed version of your application, or against an already running local server.
-   * @default `undefined`
+   * @default undefined
    */
   host?: string
   /**
    * If provided, set the launched test server port to the value.
-   * @default `undefined`
+   * @default undefined
    */
   port?: number
   env?: StartServerOptions['env']


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Standardized formatting around default values in `@default` tags. Backticks are for markdown formatting but `@default` tag doesn't format to markdown and `{}` are for objects

| Before | After |
|---|---|
| ![config-file-before](https://github.com/user-attachments/assets/0e30e8ba-9889-4924-ad48-288d174dec2a) | ![config-file-after](https://github.com/user-attachments/assets/4913da62-3e69-48f2-9e0c-5e4eb6db7d1a)
| ![server-before](https://github.com/user-attachments/assets/48bf9d1a-9db9-4b76-9b96-5a64320b85d6) | ![server-after](https://github.com/user-attachments/assets/a3306497-74e1-433e-9c55-fe65a6c5ec6d)|
| ![dom-before](https://github.com/user-attachments/assets/75760617-bd76-4918-9f84-7872d6b0beda) | ![dom-after](https://github.com/user-attachments/assets/a0b663b2-6d1a-47c1-a0f0-4033a1c55670)

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
