### PR TITLE
fix(e2e): detect nuxt config files in `.config` folder

### DIFF
--- a/examples/module/test/dot-config.test.ts
+++ b/examples/module/test/dot-config.test.ts
@@ -1,0 +1,26 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { $fetch, setup, startServer } from '@nuxt/test-utils/e2e'
+
+describe('ssr', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/dot-config', import.meta.url)),
+  })
+
+  it('renders the index page', async () => {
+    // Get response to a server-rendered page with `$fetch`.
+    const html = await $fetch('/')
+    expect(html).toContain('<div>dot-config <span>original value</span></div>')
+  })
+
+  it('changes runtime config and restarts', { timeout: 120000 }, async () => {
+    await startServer({ env: { NUXT_PUBLIC_MY_VALUE: 'overwritten by test!' } })
+
+    const html = await $fetch('/')
+    expect(html).toContain('<div>dot-config <span>overwritten by test!</span></div>')
+
+    await startServer()
+    const htmlRestored = await $fetch('/')
+    expect(htmlRestored).toContain('<div>dot-config <span>original value</span></div>')
+  })
+})

--- a/examples/module/test/fixtures/dot-config/.config/nuxt.ts
+++ b/examples/module/test/fixtures/dot-config/.config/nuxt.ts
@@ -1,0 +1,13 @@
+import MyModule from '../../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [
+    MyModule,
+  ],
+  runtimeConfig: {
+    public: {
+      myValue: 'original value',
+    },
+  },
+  compatibilityDate: '2024-04-03',
+})

--- a/examples/module/test/fixtures/dot-config/app.vue
+++ b/examples/module/test/fixtures/dot-config/app.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>dot-config <span>{{ config.public.myValue }}</span></div>
+</template>
+
+<script setup>
+const config = useRuntimeConfig()
+</script>

--- a/examples/module/test/fixtures/dot-config/package.json
+++ b/examples/module/test/fixtures/dot-config/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "example-module-dot-config-fixture",
+  "type": "module"
+}

--- a/src/e2e/nuxt.ts
+++ b/src/e2e/nuxt.ts
@@ -14,6 +14,10 @@ const isNuxtApp = (dir: string) => {
     || existsSync(resolve(dir, 'nuxt.config.mjs'))
     || existsSync(resolve(dir, 'nuxt.config.cjs'))
     || existsSync(resolve(dir, 'nuxt.config.ts'))
+    || existsSync(resolve(dir, '.config', 'nuxt.js'))
+    || existsSync(resolve(dir, '.config', 'nuxt.mjs'))
+    || existsSync(resolve(dir, '.config', 'nuxt.cjs'))
+    || existsSync(resolve(dir, '.config', 'nuxt.ts'))
   )
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #893

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Some people are using the `.config` folder alternative for projects with many configuration files, and since `c12` from `unjs` and `nuxt` itself support `.config` folder would be nice to be able run tests using this alternative :)

Added support for detecting Nuxt apps that use config files inside the `.config` folder. I hardcoded the possible resolvable configs following the same pattern as the existing for default config files. No need to set `coonfigFile` option

Also added a `dot-config` test fixture in `examples/module/test/fixtures`

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
