### PR TITLE
test: adding example tests for NuxtUI

### DIFF
--- a/examples/nuxt-ui/.gitignore
+++ b/examples/nuxt-ui/.gitignore
@@ -1,0 +1,1 @@
+.data/content/*

--- a/examples/nuxt-ui/app.vue
+++ b/examples/nuxt-ui/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <UApp>
+    <div data-testid="page-content">This is within a UApp component.</div>
+  </UApp>
+</template>

--- a/examples/nuxt-ui/assets/css/main.css
+++ b/examples/nuxt-ui/assets/css/main.css
@@ -1,0 +1,2 @@
+@import "tailwindcss";
+@import "@nuxt/ui";

--- a/examples/nuxt-ui/components/SomeComponent.vue
+++ b/examples/nuxt-ui/components/SomeComponent.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    This component has a dependency on Nuxt UI.
+    <UButton variant="solid" color="primary">Click me</UButton>
+  </div>
+</template>

--- a/examples/nuxt-ui/nuxt.config.ts
+++ b/examples/nuxt-ui/nuxt.config.ts
@@ -1,0 +1,6 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  modules: ['@nuxt/ui'],
+  compatibilityDate: '2024-04-03',
+  css: ['~/assets/css/main.css'],
+})

--- a/examples/nuxt-ui/package.json
+++ b/examples/nuxt-ui/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "example-app-vitest-nuxt-ui",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "nuxt build",
+    "dev": "nuxt dev",
+    "dev:prepare": "nuxt prepare",
+    "generate": "nuxt generate",
+    "test": "pnpm test:nuxt-environment && pnpm test:browser",
+    "test:browser": "VITEST_BROWSER_ENABLED=true vitest run",
+    "test:browser:dev": "VITEST_BROWSER_ENABLED=true vitest",
+    "test:nuxt-environment": "vitest run",
+    "preview": "nuxt preview"
+  },
+  "devDependencies": {
+    "@nuxt/test-utils": "latest",
+    "@nuxt/ui": "3.3.2",
+    "@vitest/browser": "3.2.4",
+    "nuxt": "4.0.3",
+    "tailwindcss": "^4.1.12",
+    "vitest": "3.2.4",
+    "vitest-browser-vue": "1.1.0"
+  }
+}

--- a/examples/nuxt-ui/tests/browser/index.spec.ts
+++ b/examples/nuxt-ui/tests/browser/index.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { render } from 'vitest-browser-vue'
+import App from '~/app.vue'
+
+describe('App', () => {
+  it('works with mountSuspended', async () => {
+    const component = await mountSuspended(App)
+    // expect(component.html()).toMatchInlineSnapshot(`
+    //   "<div>Index page</div>
+    //   <div>title: My page</div>"
+    // `)
+  })
+
+  it('works with vitest-browser-vue', () => {
+    const { getByText } = render(App)
+    // expect(getByText('Index page')).toBeInTheDocument()
+    // expect(getByText('title: My page')).toBeInTheDocument()
+  })
+})

--- a/examples/nuxt-ui/tests/browser/mount.spec.ts
+++ b/examples/nuxt-ui/tests/browser/mount.spec.ts
@@ -1,0 +1,8 @@
+import { expect, it } from 'vitest'
+import { render } from 'vitest-browser-vue'
+import SomeComponent from '~/components/SomeComponent.vue'
+
+it('should render any component', () => {
+  const { getByText } = render(SomeComponent)
+  expect(getByText('This component has a dependency on Nuxt UI.')).toBeInTheDocument()
+})

--- a/examples/nuxt-ui/tests/index.spec.ts
+++ b/examples/nuxt-ui/tests/index.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+
+import App from '~/app.vue'
+
+describe('test utils', () => {
+  it('can mount components within nuxt suspense', async () => {
+    const component = await mountSuspended(App)
+    expect(component.html()).toContain('<div data-testid="page-content">This is within a UApp component.</div>')
+  })
+})

--- a/examples/nuxt-ui/tests/mount.spec.ts
+++ b/examples/nuxt-ui/tests/mount.spec.ts
@@ -1,0 +1,8 @@
+import { expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import SomeComponent from '~/components/SomeComponent.vue'
+
+it('should render any component', async () => {
+  const component = await mountSuspended(SomeComponent)
+  expect(component.html()).toContain('This component has a dependency on Nuxt UI.')
+})

--- a/examples/nuxt-ui/tsconfig.json
+++ b/examples/nuxt-ui/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  // https://v3.nuxtjs.org/concepts/typescript
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/examples/nuxt-ui/vitest.config.ts
+++ b/examples/nuxt-ui/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineVitestConfig } from '@nuxt/test-utils/config'
+
+const browserConfig = {
+  browser: {
+    enabled: true,
+    provider: 'playwright',
+    instances: [{ browser: 'chromium' }],
+  },
+  environment: 'nuxt',
+  include: ['tests/browser/**/*.spec.ts'],
+  setupFiles: ['vitest-browser-vue'],
+}
+
+const defaultConfig = {
+  environment: 'nuxt',
+  exclude: ['tests/browser/**/*.spec.ts', 'node_modules/**', 'dist/**', '.data/**'],
+}
+
+export default defineVitestConfig({
+  test: process.env.VITEST_BROWSER_ENABLED === 'true' ? browserConfig : defaultConfig,
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A reference Nuxt UI example would have been helpful for me to validate that CSS and Tailwind and Nuxt instance-dependent components would work.

This is slightly redundant with the `nuxt-vitest-browser` example, but because we have a `nuxt-vitest-content` example, I think it's worth adding.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
