### PR TITLE
fix(runtime): `registerEndpoint` not working with custom fetch

### DIFF
--- a/examples/app-vitest/components/TestFetchComponent.vue
+++ b/examples/app-vitest/components/TestFetchComponent.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+async function normalFetcher() {
+  const fetcher = $fetch.create({})
+  await fetcher('/test1/')
+}
+
+async function customFetcher() {
+  const fetcher = $fetch.create({
+    onRequest() {},
+  })
+  await fetcher('/test2/')
+}
+</script>
+
+<template>
+  <div>
+    <button
+      id="normal-fetcher"
+      @click="normalFetcher"
+    >
+      normal fetch
+    </button>
+    <button
+      id="custom-fetcher"
+      @click="customFetcher"
+    >
+      custom fetch
+    </button>
+  </div>
+</template>

--- a/examples/app-vitest/test/registerEndpoint.nuxt.spec.ts
+++ b/examples/app-vitest/test/registerEndpoint.nuxt.spec.ts
@@ -1,0 +1,31 @@
+import { mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
+import { it, expect, vi, describe } from 'vitest'
+import TestFetchComponent from '../components/TestFetchComponent.vue'
+
+describe('registerEndpoint tests', () => {
+  it('/test1/ called WITHOUT onRequest intercepted', async () => {
+    const endpoint = vi.fn(() => '')
+    registerEndpoint('/test1/', () => endpoint())
+    const component = await mountSuspended(TestFetchComponent)
+
+    component
+      .find<HTMLButtonElement>('#normal-fetcher')
+      .element.click()
+
+    expect(endpoint).toHaveBeenCalled()
+    component.unmount()
+  })
+
+  it('/test2/ called WITH onRequest intercepted', async () => {
+    const endpoint = vi.fn(() => '')
+    registerEndpoint('/test2/', () => endpoint())
+    const component = await mountSuspended(TestFetchComponent)
+
+    component
+      .find<HTMLButtonElement>('#custom-fetcher')
+      .element.click()
+
+    expect(endpoint).toHaveBeenCalled()
+    component.unmount()
+  })
+})

--- a/src/runtime/shared/environment.ts
+++ b/src/runtime/shared/environment.ts
@@ -74,6 +74,11 @@ export async function setupWindow(win: NuxtWindow, environmentOptions: { nuxt: N
   // @ts-expect-error fetch types differ slightly
   win.$fetch = createFetch({ fetch: win.fetch, Headers: win.Headers })
 
+  // @ts-expect-error fetch types differ slightly
+  win.$fetch.create = (options = {}) => {
+    return createFetch({ fetch: win.fetch, Headers: win.Headers, ...options })
+  }
+
   win.__registry = registry
   win.__app = h3App
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1402

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes a bug when using `$fetch.create` with an `onRequest` interceptor.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
