### PR TITLE
feat: Add automatic ref unwrapping for wrapper.vm

### DIFF
--- a/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
@@ -191,8 +191,14 @@ describe('mountSuspended', () => {
   it('can access exposed methods/refs from components mounted within nuxt suspense', async () => {
     const component = await mountSuspended(WrapperTests)
     expect(component.vm.testExpose?.()).toBe('expose was successful')
-    // @ts-expect-error FIXME: someRef is typed as unwrapped
-    expect(component.vm.someRef.value).toBe('thing')
+    expect(component.vm.someRef).toBe('thing')
+  })
+
+  it('can modify exposed refs from components', async () => {
+    const component = await mountSuspended(WrapperTests)
+    expect(component.vm.someRef).toBe('thing')
+    component.vm.someRef = 'modified thing'
+    expect(component.vm.someRef).toBe('modified thing')
   })
 
   it('respects directives registered in nuxt plugins', async () => {

--- a/src/runtime-utils/mount.ts
+++ b/src/runtime-utils/mount.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import type { ComponentMountingOptions } from '@vue/test-utils'
-import { Suspense, h, isReadonly, nextTick, reactive, unref, getCurrentInstance } from 'vue'
+import { Suspense, h, isReadonly, nextTick, reactive, unref, getCurrentInstance, isRef } from 'vue'
 import type { ComponentInternalInstance, DefineComponent, SetupContext } from 'vue'
 import { defu } from 'defu'
 import type { RouteLocationRaw } from 'vue-router'
@@ -259,6 +259,10 @@ function wrappedMountedWrapper<T>(wrapper: ReturnType<typeof mount<T>> & { setup
         const component = target.findComponent({ name: 'MountSuspendedComponent' })
         return component[prop]
       }
+      else if (prop === 'vm') {
+        const vm = Reflect.get(target, prop, receiver)
+        return createVMProxy(vm as unknown as ComponentPublicInstance, wrapper.setupState)
+      }
       else {
         return Reflect.get(target, prop, receiver)
       }
@@ -275,4 +279,31 @@ function wrappedMountedWrapper<T>(wrapper: ReturnType<typeof mount<T>> & { setup
   }
 
   return proxy
+}
+
+function createVMProxy<T extends ComponentPublicInstance>(vm: T, setupState: Record<string, unknown>): T {
+  return new Proxy(vm, {
+    get(target, key, receiver) {
+      const value = Reflect.get(target, key, receiver)
+
+      if (setupState && typeof setupState === 'object' && key in setupState) {
+        return unref(setupState[key as keyof typeof setupState])
+      }
+
+      return value
+    },
+    set(target, key, value, receiver) {
+      if (setupState && typeof setupState === 'object' && key in setupState) {
+        const setupValue = setupState[key as keyof typeof setupState]
+        if (setupValue && isRef(setupValue)) {
+          setupValue.value = value
+          return true
+        }
+
+        return Reflect.set(setupState, key, value, receiver)
+      }
+
+      return Reflect.set(target, key, value, receiver)
+    },
+  })
 }


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1404

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, `vm` in `mountSuspended()` does not automatically unwrap refs, which is inconsistent with vue/test-utils:

```typescript
// Current behavior (inconsistent)
const component = await mountSuspended(SomeComponent)
console.log(component.vm.someRef) // Returns ref object, not the value
console.log(component.vm.someRef.value) // Need to manually access .value

// Expected behavior (vue/test-utils)
const wrapper = mount(SomeComponent)
console.log(wrapper.vm.someRef) // Returns unwrapped value
```

## Expected Behavior

`wrapper.vm` should automatically unwrap refs to match vue/test-utils:

```typescript
const component = await mountSuspended(SomeComponent)
expect(component.vm.someRef).toBe('thing') // Should work directly
component.vm.someRef = 'new thing' // Should update ref.value
expect(component.vm.someRef).toBe('new thing') // Should reflect changes
```

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
