### PR TITLE
fix: handle optional chaining for imports in `setupImportMocking` function

### DIFF
--- a/src/module/mock.ts
+++ b/src/module/mock.ts
@@ -30,7 +30,7 @@ export function setupImportMocking() {
 
   nuxt.hook('imports:sources', (presets) => {
     // because the native setInterval cannot be mocked
-    const idx = presets.findIndex(p => p.imports.includes('setInterval'))
+    const idx = presets.findIndex(p => p.imports?.includes('setInterval'))
     if (idx !== -1) {
       presets.splice(idx, 1)
     }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

None.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

#### Problem
The `setupImportMocking` function was failing when presets contained string values (e.g., `vitest`) instead of objects with an `imports` property.

```ts
export default defineNuxtConfig({
  imports: { presets: ["vitest"] },
})
```

This caused a `TypeError` when trying to access `p.imports` on string presets, breaking test execution.

```
⎯⎯⎯⎯ Startup Error ⎯⎯⎯⎯
TypeError: Cannot read properties of undefined (reading 'includes')
```

#### Solution
Added optional chaining (`?.`) to safely check if the `imports` property exists before calling `.includes('setInterval')`. This prevents errors when presets are strings rather than objects with an imports array.