### PR TITLE
fix(runtime): $fetch.create can't set the default configuration

### DIFF
--- a/examples/app-vitest/test/registerEndpoint.nuxt.spec.ts
+++ b/examples/app-vitest/test/registerEndpoint.nuxt.spec.ts
@@ -21,9 +21,9 @@ describe('registerEndpoint tests', () => {
     registerEndpoint('/test2/', () => endpoint())
     const component = await mountSuspended(TestFetchComponent)
 
-    component
+    await component
       .find<HTMLButtonElement>('#custom-fetcher')
-      .element.click()
+      .trigger('click')
 
     expect(endpoint).toHaveBeenCalled()
     component.unmount()

--- a/src/runtime/shared/environment.ts
+++ b/src/runtime/shared/environment.ts
@@ -101,11 +101,6 @@ export async function setupWindow(win: NuxtWindow, environmentOptions: { nuxt: N
   // @ts-expect-error fetch types differ slightly
   win.$fetch = createFetch({ fetch: win.fetch, Headers: win.Headers })
 
-  // @ts-expect-error fetch types differ slightly
-  win.$fetch.create = (options = {}) => {
-    return createFetch({ fetch: win.fetch, Headers: win.Headers, ...options })
-  }
-
   win.__registry = registry
   win.__app = h3App
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

$fetch.create was working correctly, but it seems the issue was caused by the assertion running too early.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
