### PR TITLE
fix(runtime-utils): pass all globalProperties in mount + render helpers

### DIFF
--- a/examples/app-vitest-full/components/ComponentWithPluginProvidedValue.vue
+++ b/examples/app-vitest-full/components/ComponentWithPluginProvidedValue.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <div id="s1">
+      {{ $pluginProvidedValues.value }}
+    </div>
+    <div id="s2">
+      {{ $pluginProvidedValues.func('value') }}
+    </div>
+    <div id="s3">
+      {{ $pluginProvidedValues.object.value }}
+    </div>
+  </div>
+</template>

--- a/examples/app-vitest-full/plugins/provided-values.ts
+++ b/examples/app-vitest-full/plugins/provided-values.ts
@@ -1,0 +1,11 @@
+export default defineNuxtPlugin(() => {
+  return {
+    provide: {
+      pluginProvidedValues: {
+        value: 'pluginProvided.value',
+        func: (value: string) => `pluginProvided.func(${value})`,
+        object: { value: 'pluginProvided.object.value' },
+      },
+    },
+  }
+})

--- a/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/mount-suspended.spec.ts
@@ -26,6 +26,7 @@ import ComponentWithReservedProp from '~/components/ComponentWithReservedProp.vu
 import ComponentWithReservedState from '~/components/ComponentWithReservedState.vue'
 import ComponentWithImports from '~/components/ComponentWithImports.vue'
 import ComponentWithCssVar from '~/components/ComponentWithCssVar.vue'
+import ComponentWithPluginProvidedValue from '~/components/ComponentWithPluginProvidedValue.vue'
 import GenericStateComponent from '~/components/GenericStateComponent.vue'
 
 import { BoundAttrs } from '#components'
@@ -282,6 +283,13 @@ describe('mountSuspended', () => {
     expect(component.find('#s1').classes()).toHaveLength(1)
     expect(component.find('#s2').classes()).toHaveLength(1)
     expect(component.find('#s3').classes()).toHaveLength(0)
+  })
+
+  it('can mount components with use plugin provided value in template', async () => {
+    const component = await mountSuspended(ComponentWithPluginProvidedValue)
+    expect(component.find('#s1').text()).toBe('pluginProvided.value')
+    expect(component.find('#s2').text()).toBe('pluginProvided.func(value)')
+    expect(component.find('#s3').text()).toBe('pluginProvided.object.value')
   })
 
   describe('Options API', () => {

--- a/examples/app-vitest-full/tests/nuxt/render-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/render-suspended.spec.ts
@@ -13,6 +13,7 @@ import ExportDefaultComponent from '~/components/ExportDefaultComponent.vue'
 import ExportDefineComponent from '~/components/ExportDefineComponent.vue'
 import ComponentWithAttrs from '~/components/ComponentWithAttrs.vue'
 import ComponentWithCssVar from '~/components/ComponentWithCssVar.vue'
+import ComponentWithPluginProvidedValue from '~/components/ComponentWithPluginProvidedValue.vue'
 import ExportDefaultWithRenderComponent from '~/components/ExportDefaultWithRenderComponent.vue'
 import ExportDefaultReturnsRenderComponent from '~/components/ExportDefaultReturnsRenderComponent.vue'
 import OptionsApiPage from '~/pages/other/options-api.vue'
@@ -177,6 +178,13 @@ describe('renderSuspended', () => {
     expect(container.querySelector('#s1')?.classList).toHaveLength(1)
     expect(container.querySelector('#s2')?.classList).toHaveLength(1)
     expect(container.querySelector('#s3')?.classList).toHaveLength(0)
+  })
+
+  it('can render components with use plugin provided value in template', async () => {
+    const { container } = await renderSuspended(ComponentWithPluginProvidedValue)
+    expect(container.querySelector('#s1')?.textContent).toBe('pluginProvided.value')
+    expect(container.querySelector('#s2')?.textContent).toBe('pluginProvided.func(value)')
+    expect(container.querySelector('#s3')?.textContent).toBe('pluginProvided.object.value')
   })
 
   describe('Options API', () => {


### PR DESCRIPTION
fix(runtime-utils): pass all globalProperties in mount + render helpers

### 🔗 Linked issue

resolves #1102 

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Non-enumerable properties were not merged and weren't set on globalProperties, so made them enumerable.
[mergeAppConfig](https://github.com/vuejs/test-utils/blob/f6a58d51b540dd7ced0e1dc97d08b7a37a813b55/src/utils.ts#L33-L36)

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
