### PR TITLE
feat(runtime-utils): support useI18n in mount + render helpers

### DIFF
--- a/examples/i18n/app.vue
+++ b/examples/i18n/app.vue
@@ -1,5 +1,9 @@
+<script setup>
+const { t } = useI18n()
+</script>
+
 <template>
   <div>
-    Hi from @nuxtjs/i18n: {{ $t('hello') }}
+    Hi from @nuxtjs/i18n: $t({{ $t('hello') }}) t({{ t('hello') }})
   </div>
 </template>

--- a/examples/i18n/test/index.spec.ts
+++ b/examples/i18n/test/index.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { mountSuspended, renderSuspended } from '@nuxt/test-utils/runtime'
 import App from '~/app.vue'
 
 describe('Mounting app with `@nuxtjs/i18n`', () => {
@@ -8,7 +8,14 @@ describe('Mounting app with `@nuxtjs/i18n`', () => {
     const component = await mountSuspended(App)
     expect(component.vm).toBeTruthy()
     expect(component.text()).toMatchInlineSnapshot(
-      `"Hi from @nuxtjs/i18n: from the en locale"`,
+      `"Hi from @nuxtjs/i18n: $t(from the en locale) t(from the en locale)"`,
+    )
+  })
+
+  it('can render some component', async () => {
+    const { container } = await renderSuspended(App)
+    expect(container.textContent.trim()).toMatchInlineSnapshot(
+      `"Hi from @nuxtjs/i18n: $t(from the en locale) t(from the en locale)"`,
     )
   })
 })

--- a/src/runtime-utils/mount.ts
+++ b/src/runtime-utils/mount.ts
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils'
 import type { ComponentMountingOptions } from '@vue/test-utils'
 import { Suspense, h, isReadonly, nextTick, reactive, unref, getCurrentInstance, effectScope, isRef } from 'vue'
-import type { ComponentInternalInstance, DefineComponent, SetupContext } from 'vue'
+import type { App, ComponentInternalInstance, DefineComponent, SetupContext } from 'vue'
 import { defu } from 'defu'
 import type { RouteLocationRaw } from 'vue-router'
 
@@ -63,7 +63,7 @@ export async function mountSuspended<T>(
     cleanupFunction()
   }
 
-  const vueApp = tryUseNuxtApp()?.vueApp
+  const vueApp: App<Element> & Record<string, unknown> = tryUseNuxtApp()?.vueApp
     // @ts-expect-error untyped global __unctx__
     || globalThis.__unctx__.get('nuxt-app').tryUse().vueApp
   const { render, setup, data, computed, methods, ...componentRest } = component as DefineComponent<Record<string, unknown>, Record<string, unknown>>
@@ -109,6 +109,16 @@ export async function mountSuspended<T>(
     currentInstance.emit = getInterceptedEmitFunction(currentInstance.emit)
   }
 
+  function patchInstanceAppContext() {
+    const app = getCurrentInstance()?.appContext.app as typeof vueApp
+    if (!app) return
+
+    for (const [key, value] of Object.entries(vueApp)) {
+      if (key in app) continue
+      app[key] = value
+    }
+  }
+
   let passedProps: Record<string, unknown>
   let componentScope: ReturnType<typeof effectScope> | null = null
 
@@ -146,6 +156,8 @@ export async function mountSuspended<T>(
         {
           __cssModules: componentRest.__cssModules,
           setup: (props: Record<string, unknown>, ctx: SetupContext) => {
+            patchInstanceAppContext()
+
             setupContext = ctx
 
             if (options?.scoped) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

resolves #743 #1152 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

the i18n plugin is installed on nuxt.vueApp however, useI18n requires `appContext.app.__VUE_I18N_SYMBOL__` to be set, which isn't configured on a vueApp created via mount or render, causing `useI18n` to fail.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
