### PR TITLE
feat(runtime-utils): support mocked target arguments in mockNuxtImport

### DIFF
--- a/examples/app-vitest-full/tests/nuxt/auto-import-mock.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/auto-import-mock.spec.ts
@@ -1,12 +1,12 @@
 import { expect, it, vi } from 'vitest'
 import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 
-mockNuxtImport<typeof useAutoImportedTarget>('useAutoImportedTarget', () => {
+mockNuxtImport(useAutoImportedTarget, () => {
   return () => 'mocked!'
 })
 
 mockNuxtImport<typeof useCustomModuleAutoImportedTarget>(
-  'useCustomModuleAutoImportedTarget',
+  useCustomModuleAutoImportedTarget,
   () => {
     return () => 'mocked!'
   },

--- a/examples/app-vitest-full/tests/setup/mocks.ts
+++ b/examples/app-vitest-full/tests/setup/mocks.ts
@@ -3,8 +3,7 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 
 vi.resetModules()
 
-mockNuxtImport<typeof useAutoImportSetupMocked>(
-  'useAutoImportSetupMocked',
+mockNuxtImport(useAutoImportSetupMocked,
   () =>
     vi.fn(() => {
       return 'mocked in setup'

--- a/src/module/plugins/mock.ts
+++ b/src/module/plugins/mock.ts
@@ -87,16 +87,19 @@ export const createMockPlugin = (ctx: MockPluginContext) => createUnplugin(() =>
               startOf(node),
             )
           }
-          const importName = node.arguments[0]!
-          if (!isLiteral(importName) || typeof importName.value !== 'string') {
+
+          const importTarget = node.arguments[0]!
+          const name = isLiteral(importTarget)
+            ? importTarget.value
+            : isIdentifier(importTarget) ? importTarget.name : undefined
+          if (typeof name !== 'string') {
             return this.error(
               new Error(
-                `The first argument of ${HELPER_MOCK_IMPORT}() must be a string literal`,
+                `The first argument of ${HELPER_MOCK_IMPORT}() must be a string literal or mocked target`,
               ),
-              startOf(importName),
+              startOf(importTarget),
             )
           }
-          const name = importName.value
           const importItem = ctx.imports.find(_ => name === (_.as || _.name))
           if (!importItem) {
             console.log({ imports: ctx.imports })

--- a/src/runtime-utils/mock.ts
+++ b/src/runtime-utils/mock.ts
@@ -99,7 +99,7 @@ export function registerEndpoint(url: string, options: EventHandler | { handler:
 
 /**
  * `mockNuxtImport` allows you to mock Nuxt's auto import functionality.
- * @param _name - name of an import to mock.
+ * @param _target - name of an import to mock or mocked target.
  * @param _factory - factory function that returns mocked import.
  * @example
  * ```ts
@@ -110,11 +110,18 @@ export function registerEndpoint(url: string, options: EventHandler | { handler:
  *    return { value: 'mocked storage' }
  *  }
  * })
+ *
+ * // With mocked target
+ * mockNuxtImport(useStorage, () => {
+ *  return () => {
+ *    return { value: 'mocked storage' }
+ *  }
+ * })
  * ```
  * @see https://nuxt.com/docs/getting-started/testing#mocknuxtimport
  */
 export function mockNuxtImport<T = unknown>(
-  _name: string,
+  _target: string | T,
   _factory: () => T | Promise<T>,
 ): void {
   throw new Error(

--- a/test/unit/mock-transform.spec.ts
+++ b/test/unit/mock-transform.spec.ts
@@ -43,12 +43,7 @@ describe('mocking', () => {
         name: 'useSomeExport',
         from: 'bob',
       }]
-      expect(await getResult(`
-        import { mockNuxtImport } from '@nuxt/test-utils/runtime'
-        mockNuxtImport('useSomeExport', () => {
-          return () => 'mocked'
-        })
-      `)).toMatchInlineSnapshot(`
+      const expected = `
         "import {vi} from "vitest";
 
         vi.hoisted(() => { 
@@ -72,8 +67,22 @@ describe('mocking', () => {
                 
               
          import "bob";"
-      `)
+      `
+      expect(await getResult(`
+        import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+        mockNuxtImport('useSomeExport', () => {
+          return () => 'mocked'
+        })
+      `)).toMatchInlineSnapshot(expected)
+
+      expect(await getResult(`
+        import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+        mockNuxtImport(useSomeExport, () => {
+          return () => 'mocked'
+        })
+      `)).toMatchInlineSnapshot(expected)
     })
+
     it('should not add `vi` import if it already exists', async () => {
       pluginContext.imports = [{
         name: 'useSomeExport',


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

the following syntax using the `mockNuxtImport` macro
```ts
mockNuxtImport<typeof useAutoImportedTarget>('useAutoImportedTarget', () => {
  return () => 'mocked!'
})
```
will be replaceable by the following form
```ts
mockNuxtImport(useAutoImportedTarget, () => {
  return () => 'mocked!'
})
```
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
