### PR TITLE
feat(runtime)!: change nuxt start timing to beforeAll hook

### DIFF
--- a/examples/app-vitest-full/components/InjectedValueComponent.vue
+++ b/examples/app-vitest-full/components/InjectedValueComponent.vue
@@ -1,11 +1,16 @@
 <template>
   <div>
-    {{ value }}
+    <span>{{ value1 }}</span>
+    <span>{{ value2 }}</span>
   </div>
 </template>
 
 <script setup lang="ts">
-import { CUSTOM_VUE_PLUGIN_SYMBOL } from '../plugins/inject-value'
+import {
+  CUSTOM_VUE_PLUGIN_SYMBOL,
+  CUSTOM_VUE_PLUGIN_SYMBOL2,
+} from '../plugins/inject-value'
 
-const value = inject(CUSTOM_VUE_PLUGIN_SYMBOL)
+const value1 = inject(CUSTOM_VUE_PLUGIN_SYMBOL)
+const value2 = inject(CUSTOM_VUE_PLUGIN_SYMBOL2)
 </script>

--- a/examples/app-vitest-full/components/WithNuxtCoreComposables.vue
+++ b/examples/app-vitest-full/components/WithNuxtCoreComposables.vue
@@ -1,0 +1,52 @@
+<template>
+  <div>
+    <button
+      id="tryUseNuxtApp-callHook"
+      @click="tryNuxtApp?.callHook(callHook)"
+    >
+      tryNuxtApp?.callHook
+    </button>
+    <button
+      id="useNuxtApp-callHook"
+      @click="nuxtApp.callHook(callHook)"
+    >
+      nuxtApp.callHook
+    </button>
+    <div id="useRuntimeConfig-public-API_ENTRYPOINT">
+      {{ config.public.API_ENTRYPOINT }}
+    </div>
+    <div id="useRoute-path">
+      {{ route.path }}
+    </div>
+    <button
+      id="useRouter-push"
+      @click="router.push(pushPath)"
+    >
+      useRouter.push
+    </button>
+    <button
+      id="navigateTo"
+      @click="navigateTo(pushPath)"
+    >
+      navigateTo
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { NuxtApp } from '#app'
+
+const {
+  callHook = 'page:finish',
+  pushPath = '/push-path',
+} = defineProps<{
+  callHook?: Parameters<NuxtApp['callHook']>[0]
+  pushPath?: string
+}>()
+
+const tryNuxtApp = tryUseNuxtApp()
+const nuxtApp = useNuxtApp()
+const config = useRuntimeConfig()
+const route = useRoute()
+const router = useRouter()
+</script>

--- a/examples/app-vitest-full/composables/useGlobalCounter.ts
+++ b/examples/app-vitest-full/composables/useGlobalCounter.ts
@@ -1,0 +1,11 @@
+export default function useGlobalCounter() {
+  const count = useState('GlobalCounter', () => 0)
+
+  return {
+    count,
+    increment: () => {
+      count.value++
+      return count.value
+    },
+  }
+}

--- a/examples/app-vitest-full/middleware/01.global-counter.global.ts
+++ b/examples/app-vitest-full/middleware/01.global-counter.global.ts
@@ -1,0 +1,7 @@
+export default defineNuxtRouteMiddleware((to, _from) => {
+  const { increment } = useGlobalCounter()
+  if (to.path === '/count/just/1000') return
+  if (increment() === 1000) {
+    return navigateTo('/count/just/1000')
+  }
+})

--- a/examples/app-vitest-full/plugins/global-counter.ts
+++ b/examples/app-vitest-full/plugins/global-counter.ts
@@ -1,0 +1,7 @@
+export default defineNuxtPlugin(() => {
+  return {
+    provide: {
+      counter: useGlobalCounter(),
+    },
+  }
+})

--- a/examples/app-vitest-full/plugins/inject-value.ts
+++ b/examples/app-vitest-full/plugins/inject-value.ts
@@ -1,14 +1,16 @@
 import type { Plugin } from 'vue'
 
-// TODO: investigate why `Symbol()` export without global registry doesn't match
 export const CUSTOM_VUE_PLUGIN_SYMBOL = Symbol.for('CUSTOM_VUE_PLUGIN_INJECTED')
-
 export const VUE_INJECTED_VALUE = 'injected vue plugin value'
+
+export const CUSTOM_VUE_PLUGIN_SYMBOL2 = Symbol('CUSTOM_VUE_PLUGIN_INJECTED_WITHOUT_GLOBAL_REGISTRY')
+export const VUE_INJECTED_VALUE2 = 'injected vue plugin value without global registry'
 
 export default defineNuxtPlugin((nuxtApp) => {
   const vuePlugin: Plugin = {
     install(app) {
       app.provide(CUSTOM_VUE_PLUGIN_SYMBOL, VUE_INJECTED_VALUE)
+      app.provide(CUSTOM_VUE_PLUGIN_SYMBOL2, VUE_INJECTED_VALUE2)
     },
   }
 

--- a/examples/app-vitest-full/tests/nuxt/injected-value-component.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/injected-value-component.spec.ts
@@ -1,12 +1,31 @@
 import { describe, expect, it } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 
-import { VUE_INJECTED_VALUE } from '~/plugins/inject-value'
+import {
+  CUSTOM_VUE_PLUGIN_SYMBOL,
+  CUSTOM_VUE_PLUGIN_SYMBOL2,
+  VUE_INJECTED_VALUE,
+  VUE_INJECTED_VALUE2,
+} from '~/plugins/inject-value'
+
 import InjectedValueComponent from '~/components/InjectedValueComponent.vue'
 
 describe('InjectedValueComponent', () => {
   it('can use injected values from a plugin', async () => {
     const component = await mountSuspended(InjectedValueComponent)
-    expect(component.text()).toContain(VUE_INJECTED_VALUE)
+    expect(component.html()).toContain(`<span>${VUE_INJECTED_VALUE}</span>`)
+    expect(component.html()).toContain(`<span>${VUE_INJECTED_VALUE2}</span>`)
+  })
+
+  it('can inject `Symbol.for()`', () => {
+    useNuxtApp().runWithContext(() => {
+      expect(inject(CUSTOM_VUE_PLUGIN_SYMBOL)).toBe(VUE_INJECTED_VALUE)
+    })
+  })
+
+  it('can inject `Symbol()`', () => {
+    useNuxtApp().runWithContext(() => {
+      expect(inject(CUSTOM_VUE_PLUGIN_SYMBOL2)).toBe(VUE_INJECTED_VALUE2)
+    })
   })
 })

--- a/examples/app-vitest-full/tests/nuxt/middleware.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/middleware.spec.ts
@@ -1,0 +1,58 @@
+import { it, describe, expect, beforeEach, vi } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+const {
+  incrementMock,
+} = vi.hoisted(() => ({
+  incrementMock: vi.fn(),
+}))
+
+mockNuxtImport(useGlobalCounter, () => () => ({
+  count: ref(100),
+  increment: incrementMock,
+}))
+
+mockNuxtImport(navigateTo, original => vi.fn(original))
+
+describe('middleware', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('can mock composable inside global middleware', async () => {
+    const { count } = useGlobalCounter()
+    expect(incrementMock).not.toBeCalled()
+
+    await navigateTo({ path: '/', force: true })
+
+    expect(count.value).toBe(100)
+    expect(incrementMock).toHaveBeenCalledOnce()
+  })
+
+  it('can use original nuxt core composable inside middleware', async () => {
+    const route = useRoute()
+
+    incrementMock.mockImplementation(() => 1000)
+
+    await navigateTo({ path: '/', force: true })
+
+    expect(route.path).toBe('/count/just/1000')
+    expect(incrementMock).toHaveBeenCalledOnce()
+  })
+
+  it('can mock nuxt core composable inside middleware', async () => {
+    const route = useRoute()
+
+    const navigateToMock = vi.mocked(navigateTo)
+    const navigateToOriginal = navigateToMock.getMockImplementation()!
+
+    navigateToMock.mockImplementation(() => Promise.resolve())
+    incrementMock.mockImplementation(() => 1000)
+
+    await navigateToOriginal({ path: '/', force: true })
+
+    expect(route.path).toBe('/')
+    expect(incrementMock).toHaveBeenCalledOnce()
+    expect(navigateToMock).toHaveBeenLastCalledWith('/count/just/1000')
+  })
+})

--- a/examples/app-vitest-full/tests/nuxt/mock-nuxt-composable-1.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/mock-nuxt-composable-1.spec.ts
@@ -1,16 +1,169 @@
-import { expect, it } from 'vitest'
-import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-mockNuxtImport('useRuntimeConfig', () => {
-  return () => {
-    return {
-      public: { API_ENTRYPOINT: 'http://api.example.com' },
-    }
-  }
-})
+import { enableAutoUnmount } from '@vue/test-utils'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 
-it('should mock core nuxt composables', () => {
-  expect(useRuntimeConfig().public?.API_ENTRYPOINT).toMatchInlineSnapshot(
-    '"http://api.example.com"',
-  )
+import Component from '~/components/WithNuxtCoreComposables.vue'
+
+mockNuxtImport(tryUseNuxtApp, original => vi.fn(original))
+mockNuxtImport(useNuxtApp, original => vi.fn(original))
+mockNuxtImport(useRuntimeConfig, original => vi.fn(original))
+mockNuxtImport(useRoute, original => vi.fn(original))
+mockNuxtImport(useRouter, original => vi.fn(original))
+mockNuxtImport(navigateTo, original => vi.fn(original))
+
+describe('mock core nuxt composables', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  enableAutoUnmount(afterEach)
+
+  describe('tryUseNuxtApp', () => {
+    it('should mock', async () => {
+      vi.spyOn(tryUseNuxtApp()!, 'callHook').mockImplementation(async () => 'mocked')
+      vi.mocked(tryUseNuxtApp).mockClear()
+
+      expect(tryUseNuxtApp).not.toHaveBeenCalled()
+      const nuxtApp = tryUseNuxtApp()!
+      expect(tryUseNuxtApp).toHaveBeenCalled()
+
+      expect(await nuxtApp.callHook('page:finish', null!)).toBe('mocked')
+      expect(nuxtApp.callHook).toHaveBeenLastCalledWith('page:finish', null!)
+    })
+
+    it('should mock inside component', async () => {
+      vi.spyOn(tryUseNuxtApp()!, 'callHook').mockImplementation(async () => 'mocked')
+      vi.mocked(tryUseNuxtApp).mockClear()
+
+      expect(tryUseNuxtApp).not.toHaveBeenCalled()
+      const wrapper = await mountSuspended(Component, { props: { callHook: 'page:finish' } })
+      expect(tryUseNuxtApp).toHaveBeenCalled()
+
+      await wrapper.find('#tryUseNuxtApp-callHook').trigger('click')
+      expect(tryUseNuxtApp()!.callHook).toHaveBeenLastCalledWith('page:finish')
+    })
+  })
+
+  describe('useNuxtApp', () => {
+    it('should mock', async () => {
+      vi.spyOn(useNuxtApp(), 'callHook').mockImplementation(async () => 'mocked')
+      vi.mocked(useNuxtApp).mockClear()
+
+      expect(useNuxtApp).not.toHaveBeenCalled()
+      const nuxtApp = useNuxtApp()
+      expect(useNuxtApp).toHaveBeenCalledOnce()
+
+      expect(await nuxtApp.callHook('page:finish', null!)).toBe('mocked')
+      expect(nuxtApp.callHook).toHaveBeenLastCalledWith('page:finish', null!)
+    })
+
+    it('should mock inside component', async () => {
+      vi.spyOn(useNuxtApp(), 'callHook').mockImplementation(async () => 'mocked')
+      vi.mocked(useNuxtApp).mockClear()
+
+      expect(useNuxtApp).not.toHaveBeenCalled()
+      const wrapper = await mountSuspended(Component, { props: { callHook: 'page:finish' } })
+      expect(useNuxtApp).toHaveBeenCalled()
+
+      await wrapper.find('#useNuxtApp-callHook').trigger('click')
+      expect(useNuxtApp().callHook).toHaveBeenLastCalledWith('page:finish')
+    })
+  })
+
+  describe('useRuntimeConfig', () => {
+    beforeEach(() => {
+      const config = useRuntimeConfig()
+      vi.spyOn(config, 'public', 'get').mockReturnValue({ ...config.public, API_ENTRYPOINT: 'http://api.example.com' })
+      vi.mocked(useRuntimeConfig).mockClear()
+    })
+
+    it('should mock', () => {
+      expect(useRuntimeConfig).not.toHaveBeenCalled()
+      const config = useRuntimeConfig()
+      expect(useRuntimeConfig).toHaveBeenCalled()
+
+      expect(config.public.API_ENTRYPOINT).toBe('http://api.example.com')
+    })
+
+    it('should mock inside component', async () => {
+      expect(useRuntimeConfig).not.toHaveBeenCalled()
+      const wrapper = await mountSuspended(Component)
+      expect(useRuntimeConfig).toHaveBeenCalled()
+
+      expect(wrapper.find('#useRuntimeConfig-public-API_ENTRYPOINT').text()).toBe('http://api.example.com')
+    })
+  })
+
+  describe('useRoute', () => {
+    it('should mock', async () => {
+      const useRouteMock = vi.mocked(useRoute)
+      const useRouteOriginal = useRouteMock.getMockImplementation()!
+      useRouteMock.mockImplementation(
+        (...args) => ({ ...useRouteOriginal(...args), path: '/mocked' }),
+      )
+
+      expect(useRoute).not.toHaveBeenCalled()
+      const route = useRoute()
+      expect(useRoute).toHaveBeenCalled()
+
+      expect(route.path).toBe('/mocked')
+    })
+
+    it('should mock inside component', async () => {
+      const useRouteMock = vi.mocked(useRoute)
+      const useRouteOriginal = useRouteMock.getMockImplementation()!
+      useRouteMock.mockImplementation(
+        (...args) => ({ ...useRouteOriginal(...args), path: '/mocked' }),
+      )
+
+      expect(useRoute).not.toHaveBeenCalled()
+      const wrapper = await mountSuspended(Component)
+      expect(useRoute).toHaveBeenCalled()
+
+      expect(wrapper.find('#useRoute-path').text()).toBe('/mocked')
+    })
+  })
+
+  describe('useRouter', () => {
+    it('should mock', async () => {
+      vi.spyOn(useRouter(), 'push').mockImplementation(async () => {})
+      vi.mocked(useRouter).mockClear()
+
+      expect(useRouter).not.toHaveBeenCalled()
+      const router = useRouter()
+      expect(useRouter).toHaveBeenCalled()
+
+      await router.push('/mocked')
+      expect(router.push).toHaveBeenLastCalledWith('/mocked')
+    })
+
+    it('should mock inside component', async () => {
+      vi.spyOn(useRouter(), 'push').mockImplementation(async () => {})
+      vi.mocked(useRouter).mockClear()
+
+      expect(useRouter).not.toHaveBeenCalled()
+      const wrapper = await mountSuspended(Component, { props: { pushPath: '/mocked' } })
+      expect(useRouter).toHaveBeenCalled()
+
+      await wrapper.find('#useRouter-push').trigger('click')
+      expect(useRouter().push).toHaveBeenLastCalledWith('/mocked')
+    })
+  })
+
+  describe('navigateTo', () => {
+    it('should mock', async () => {
+      vi.mocked(navigateTo).mockImplementation(async () => {})
+      await navigateTo('/mocked')
+      expect(navigateTo).toHaveBeenLastCalledWith('/mocked')
+    })
+
+    it('should mock inside component', async () => {
+      vi.mocked(navigateTo).mockImplementation(async () => {})
+      const wrapper = await mountSuspended(Component, { props: { pushPath: '/mocked' } })
+      await wrapper.find('#navigateTo').trigger('click')
+      expect(navigateTo).toHaveBeenLastCalledWith('/mocked')
+    })
+  })
 })

--- a/examples/app-vitest-full/tests/nuxt/mock-vue-router.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/mock-vue-router.spec.ts
@@ -1,25 +1,48 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { useRoute as useVueRoute } from 'vue-router'
+
 import Index from '~/pages/router/route.vue'
 
-vi.mock('vue-router', () => ({
-  useRoute: vi.fn(() => ({
-    meta: {},
-    path: '/123',
-    query: {},
-  })),
-}))
+vi.mock(import('vue-router'), async (importOriginal) => {
+  const original = await importOriginal()
+  return {
+    ...original,
+    useRoute: vi.fn(original.useRoute),
+  }
+})
 
-mockNuxtImport('useRoute', () => () => ({
-  meta: {},
-  path: '/bob',
-  query: {},
-}))
+mockNuxtImport<typeof useRoute>('useRoute', original => vi.fn(original))
 
 describe('Index', async () => {
-  const wrapper = await mountSuspended(Index)
+  const useRouteMock = vi.mocked(useRoute)
+  const useVueRouteMock = vi.mocked(useVueRoute)
 
-  it('should render correctly', () => {
+  const useRouteOriginal = useRouteMock.getMockImplementation()!
+  const useVueRouteOriginal = useVueRouteMock.getMockImplementation()!
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('should render correctly', async () => {
+    useRouteMock.mockImplementation((...args) => ({
+      ...useRouteOriginal(...args),
+      path: '/bob',
+    }))
+
+    useVueRouteMock.mockImplementation((...args) => ({
+      ...useVueRouteOriginal(...args),
+      path: '/123',
+    }))
+
+    expect(useRouteMock).not.toBeCalled()
+    expect(useVueRouteMock).not.toBeCalled()
+
+    const wrapper = await mountSuspended(Index)
     expect(wrapper.html()).toMatchSnapshot()
+
+    expect(useRouteMock).toBeCalled()
+    expect(useVueRouteMock).toBeCalled()
   })
 })

--- a/examples/app-vitest-full/tests/nuxt/plugins.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/plugins.spec.ts
@@ -1,9 +1,35 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+const { incrementMock } = vi.hoisted(() => ({
+  incrementMock: vi.fn(() => 100),
+}))
+
+mockNuxtImport(useGlobalCounter, () => () => ({
+  count: ref(100),
+  increment: incrementMock,
+}))
 
 describe('plugins', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
   it('can access injections', () => {
     const app = useNuxtApp()
     expect(app.$auth.didInject).toMatchInlineSnapshot('true')
     expect(app.$router).toBeDefined()
+  })
+
+  it('can mock composable inside plugin', () => {
+    const { count, increment } = useNuxtApp().$counter
+
+    expect(count.value).toBe(100)
+    expect(incrementMock).not.toBeCalled()
+
+    expect(increment()).toBe(100)
+
+    expect(count.value).toBe(100)
+    expect(incrementMock).toHaveBeenCalledOnce()
   })
 })

--- a/examples/app-vitest-full/tests/resolved-files.spec.ts
+++ b/examples/app-vitest-full/tests/resolved-files.spec.ts
@@ -2,7 +2,7 @@ import { fileURLToPath } from 'node:url'
 import { test, expect } from 'vitest'
 import { createVitest } from 'vitest/node'
 
-test('it should include nuxt spec files', { timeout: 30000 }, async () => {
+test('it should include nuxt spec files', { timeout: 30000 }, async ({ onTestFinished }) => {
   const vitest = await createVitest('test', {
     config: fileURLToPath(new URL('../vitest.config.ts', import.meta.url)),
     dir: fileURLToPath(new URL('../', import.meta.url)),
@@ -10,21 +10,15 @@ test('it should include nuxt spec files', { timeout: 30000 }, async () => {
     run: false,
     watch: false,
   })
+
+  onTestFinished(async () => {
+    await vitest.close()
+  })
+
   const testFiles = await vitest.globTestSpecifications()
+  const nuxtSpecFiles = testFiles.filter(file => file.project.name === 'nuxt')
+  const regularSpecFiles = testFiles.filter(file => file.project.name === 'node')
 
-  await vitest.close()
-
-  const NUXT_PATH_RE = /[\\/]tests[\\/]nuxt[\\/]/
-  const nuxtSpecFiles = testFiles.filter(file => file.moduleId.endsWith('nuxt.spec.ts') || NUXT_PATH_RE.test(file.moduleId))
-  const regularSpecFiles = testFiles.filter(file => file.moduleId.endsWith('.spec.ts') && !file.moduleId.endsWith('nuxt.spec.ts') && !NUXT_PATH_RE.test(file.moduleId))
-
-  expect(nuxtSpecFiles.length).toEqual(25)
-  for (const file of nuxtSpecFiles) {
-    expect(file.project.name).toEqual('nuxt')
-  }
-
+  expect(nuxtSpecFiles.length).toEqual(26)
   expect(regularSpecFiles.length).toEqual(2)
-  for (const file of regularSpecFiles) {
-    expect(file.project.name).toEqual('node')
-  }
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,6 +436,25 @@ importers:
         specifier: 2.0.1
         version: 2.0.1(vitest@4.0.17)(vue@3.5.27(typescript@5.9.3))
 
+  examples/env-options:
+    dependencies:
+      nuxt:
+        specifier: ^4.2.2
+        version: 4.2.2(@parcel/watcher@2.5.1)(@types/node@24.10.9)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.6.2))(eslint@9.39.2(jiti@2.6.1))(idb-keyval@6.2.2)(ioredis@5.9.1)(lightningcss@1.30.2)(magicast@0.5.1)(optionator@0.9.4)(rollup@4.55.2)(terser@5.44.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vue-tsc@3.2.2(typescript@5.9.3))(yaml@2.8.2)
+    devDependencies:
+      '@nuxt/test-utils':
+        specifier: workspace:*
+        version: link:../..
+      happy-dom:
+        specifier: 20.3.3
+        version: 20.3.3
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.0.17
+        version: 4.0.17(@types/node@24.10.9)(@vitest/browser-playwright@4.0.17)(@vitest/ui@4.0.17)(happy-dom@20.3.3)(jiti@2.6.1)(jsdom@27.4.0(postcss@8.5.6))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+
   examples/i18n:
     devDependencies:
       '@nuxt/test-utils':

--- a/src/runtime/entry.ts
+++ b/src/runtime/entry.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { beforeAll } from 'vitest'
 import { setupNuxt } from './shared/nuxt'
 
 if (
@@ -6,8 +6,9 @@ if (
   // @ts-expect-error undefined property
   && window.__NUXT_VITEST_ENVIRONMENT__
 ) {
-  await setupNuxt()
-  vi.resetModules()
+  beforeAll(async () => {
+    await setupNuxt()
+  })
 }
 
 export {}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

resolves #750 
resolves #836 
resolves #1185 
resolves #1496 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

The timing for starting Nuxt has been moved from setupFiles to `beforeAll` hook. This change enables mocking of composables that are loaded during Nuxt initialization.

Please note that migration is required for certain cases, such as test code that partially mocks Nuxt core composables, or code that mounts components outside of the test suite (which requires Nuxt to be initialized). Modifying the test code is required for these patterns to function.

Since `mockNuxtImport` now provides the original composable, we will update the test code to use the original implementation as much as possible to ensure Nuxt initialization doesn't fail, while mocking only the necessary parts for each test.

Example:
```ts
mockNuxtImport(useRoute, original => vi.fn(original))
mockNuxtImport(useRouter, original => vi.fn(original))
mockNuxtImport(navigateTo, original => vi.fn(original))

it('useRoute', async () => {
  const useRouteMock = vi.mocked(useRoute).mockClear()
  const useRouteOriginal = useRouteMock.getMockImplementation()!
  useRouteMock.mockImplementation(
    (...args) => ({ ...useRouteOriginal(...args), path: '/mocked' }),
  )

  expect(useRoute).not.toHaveBeenCalled()
  const wrapper = await mountSuspended(Component)
  expect(useRoute).toHaveBeenCalled()

  expect(wrapper.find('#useRoute-path').text()).toBe('/mocked')
})

it('useRouter', async () => {
  vi.spyOn(useRouter(), 'push').mockImplementation(async () => {})
  vi.mocked(useRouter).mockClear()

  expect(useRouter).not.toHaveBeenCalled()
  const wrapper = await mountSuspended(Component, { props: { pushPath: '/mocked' } })
  expect(useRouter).toHaveBeenCalled()

  await wrapper.find('#useRouter-push').trigger('click')
  expect(useRouter().push).toHaveBeenLastCalledWith('/mocked')
})

it('navigateTo', async () => {
  vi.mocked(navigateTo).mockClear().mockImplementation(async () => {})
  await navigateTo('/mocked')
  expect(navigateTo).toHaveBeenLastCalledWith('/mocked')
})
```

For cases where components are mounted outside of the test suite, there are options to either move the mounting logic inside the test suite or perform the mount within `beforeAll` hook.

Example:
```ts
// component mounting will now fail here.
// const wrapper1 = await mountSuspended(SomeComponent)

describe('Some Component', async () => {
  // component mounting will now fail here.
  // const wrapper1 = await mountSuspended(SomeComponent)

  let wrapper2: Awaited<ReturnType<typeof mountSuspended<typeof SomeComponent>>>

  beforeAll(async () => {
    wrapper2 = await mountSuspended(SomeComponent)
  })

  it('some test', async () => {
    const wrapper1 = await mountSuspended(SomeComponent)
    expect(wrapper1.text()).toBe('ok')
    expect(wrapper2.text()).toBe('ok')
  })
})
```

### Reproductions

- [stackblitz for issue 750](https://stackblitz.com/edit/github-3r1bkqep?file=package.json)
- [stackblitz for issue 836](https://stackblitz.com/edit/github-zqexwa-j588vhmk?file=package.json)
- [stackblitz for issue 1185](https://stackblitz.com/edit/github-mmtufx-s4v5vbll?file=vitest.config.ts)
  expected: `eventBus $on EVENT XXX`, the `XXX` values match, and `app.vue - onEvent()` is logged.
  ```
  eventBus $on EVENT 660
  eventBus $on EVENT 660
  eventBus $emit EVENT 660
  app.vue - onEvent() {msg: 'utils/eventBus'}
  index.vue - onEvent() {msg: 'utils/eventBus'
  ```

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
