### PR TITLE
fix(runtime-utils): avoid missing render warn on reject render + suspend helpers

### DIFF
--- a/src/runtime-utils/mount.ts
+++ b/src/runtime-utils/mount.ts
@@ -180,6 +180,7 @@ export async function mountSuspended<T>(
               {
                 onResolve: () =>
                   nextTick().then(() => {
+                    if (isMountSettled) return
                     isMountSettled = true;
                     (vm as unknown as AugmentedVueInstance).setupState = setupState;
                     (vm as unknown as AugmentedVueInstance).__setProps = (props: Record<string, unknown>) => {
@@ -192,6 +193,7 @@ export async function mountSuspended<T>(
                 default: () =>
                   h({
                     name: 'MountSuspendedHelper',
+                    render: () => '',
                     async setup() {
                       const router = useRouter()
                       await router.replace(route)

--- a/src/runtime-utils/render.ts
+++ b/src/runtime-utils/render.ts
@@ -168,6 +168,7 @@ export async function renderSuspended<T>(component: T, options?: RenderSuspendeO
                 {
                   onResolve: () =>
                     nextTick().then(() => {
+                      if (isMountSettled) return
                       isMountSettled = true;
                       (utils as unknown as AugmentedVueInstance).setupState = setupState
                       utils.rerender = async (props) => {
@@ -181,6 +182,7 @@ export async function renderSuspended<T>(component: T, options?: RenderSuspendeO
                   default: () =>
                     h({
                       name: 'RenderHelper',
+                      render: () => '',
                       async setup() {
                         const router = useRouter()
                         await router.replace(route)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Suppressed Vue warnings regarding missing templates when middleware errors occur during router.replace in renderSuspended or mountSuspended.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
