### PR TITLE
feat(runtime-utils): unify logic of mount + render helpers

### DIFF
--- a/examples/app-vitest-full/tests/nuxt/render-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/render-suspended.spec.ts
@@ -8,6 +8,7 @@ import OptionsComponent from '~/components/OptionsComponent.vue'
 import WrapperTests from '~/components/WrapperTests.vue'
 import LinkTests from '~/components/LinkTests.vue'
 import DirectiveComponent from '~/components/DirectiveComponent.vue'
+import CustomComponent from '~/components/CustomComponent.vue'
 
 import ExportDefaultComponent from '~/components/ExportDefaultComponent.vue'
 import ExportDefineComponent from '~/components/ExportDefineComponent.vue'
@@ -92,6 +93,13 @@ describe('renderSuspended', () => {
       "<div id="test-wrapper">
         <div data-directive="true"></div>
       </div>"
+    `)
+  })
+
+  it('respects custom component registered in nuxt plugins', async () => {
+    const component = await renderSuspended(CustomComponent)
+    expect(component.html()).toMatchInlineSnapshot(`
+    "<div id="test-wrapper"><button data-testid="test-button"> Button in TestButton component </button></div>"
     `)
   })
 

--- a/src/runtime-utils/render.ts
+++ b/src/runtime-utils/render.ts
@@ -1,24 +1,12 @@
-import { Suspense, effectScope, h, nextTick, reactive, defineComponent, getCurrentInstance } from 'vue'
-import type { App, ComponentInternalInstance, DefineComponent, SetupContext } from 'vue'
-import type { RenderResult, RenderOptions as TestingLibraryRenderOptions } from '@testing-library/vue'
-import { defu } from 'defu'
-import type { RouteLocationRaw } from 'vue-router'
+import { h } from 'vue'
+import { cleanupAll, wrapperSuspended } from './utils/suspended'
+import type { WrapperSuspendedOptions, WrapperSuspendedResult } from './utils/suspended'
 
-import { RouterLink } from './components/RouterLink'
+import type { render } from '@testing-library/vue'
 
-import NuxtRoot from '#build/root-component.mjs'
-import { tryUseNuxtApp, useRouter, onErrorCaptured } from '#imports'
-
-type RenderSuspendeOptions<T> = TestingLibraryRenderOptions<T> & {
-  route?: RouteLocationRaw
-}
-
-type RenderSuspendeResult = RenderResult & { setupState: SetupState }
-
-const WRAPPER_EL_ID = 'test-wrapper'
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type SetupState = Record<string, any>
+type WrapperFn<C> = typeof render<C>
+type WrapperOptions<C> = WrapperSuspendedOptions<WrapperFn<C>>
+type WrapperResult<C> = WrapperSuspendedResult<WrapperFn<C>>
 
 /**
  * `renderSuspended` allows you to mount any vue component within the Nuxt environment, allowing async setup and access to injections from your Nuxt plugins.
@@ -50,191 +38,33 @@ type SetupState = Record<string, any>
  * @param component the component to be tested
  * @param options optional options to set up your component
  */
-export async function renderSuspended<T>(component: T, options?: RenderSuspendeOptions<T>) {
-  const {
-    props = {},
-    attrs = {},
-    slots = {},
-    route = '/',
-    ..._options
-  } = options || {}
+export async function renderSuspended<T>(
+  component: T,
+  options: WrapperOptions<T> = {},
+): Promise<WrapperResult<T>> {
+  const wrapperId = 'test-wrapper'
+  const suspendedHelperName = 'RenderHelper'
+  const clonedComponentName = 'RenderSuspendedComponent'
 
-  const { render: renderFromTestingLibrary } = await import('@testing-library/vue')
+  const { render: wrapperFn } = await import('@testing-library/vue')
 
-  const vueApp: App<Element> & Record<string, unknown> = tryUseNuxtApp()?.vueApp
-    // @ts-expect-error untyped global __unctx__
-    || globalThis.__unctx__.get('nuxt-app').tryUse().vueApp
-  const { render, setup, ...componentRest } = component as DefineComponent<Record<string, unknown>, Record<string, unknown>>
+  cleanupAll()
+  document.getElementById(wrapperId)?.remove()
 
-  let wrappedInstance: ComponentInternalInstance | null = null
-  let setupContext: SetupContext
-  let setupState: SetupState
-
-  const setProps = reactive<Record<string, unknown>>({})
-
-  function patchInstanceAppContext() {
-    const app = getCurrentInstance()?.appContext.app as typeof vueApp
-    if (!app) return
-
-    for (const [key, value] of Object.entries(vueApp)) {
-      if (key in app) continue
-      app[key] = value
-    }
-  }
-
-  // cleanup previously mounted test wrappers
-  for (const fn of window.__cleanup || []) {
-    fn()
-  }
-  document.querySelector(`#${WRAPPER_EL_ID}`)?.remove()
-
-  const wrappedSetup = async (
-    props: Record<string, unknown>,
-    setupContext: SetupContext,
-    instanceContext: SetupContext,
-  ): Promise<unknown> => {
-    const currentInstance = getCurrentInstance()
-    if (currentInstance) {
-      currentInstance.emit = (event, ...args) => {
-        setupContext.emit(event, ...args)
-      }
-    }
-
-    if (setup) {
-      const result = await setup(props, setupContext)
-      setupState = result && typeof result === 'object' ? result : {}
-      if (wrappedInstance?.exposed) {
-        instanceContext.expose(wrappedInstance.exposed)
-      }
-      return result
-    }
-  }
-
-  const WrapperComponent = defineComponent({
-    inheritAttrs: false,
-    render() {
-      return h('div', { id: WRAPPER_EL_ID }, this.$slots.default?.())
-    },
+  const { wrapper, setProps } = await wrapperSuspended(component, options, {
+    wrapperFn,
+    wrappedRender: render => () => h({
+      inheritAttrs: false,
+      render: () => h('div', { id: wrapperId }, render()),
+    }),
+    suspendedHelperName,
+    clonedComponentName,
   })
-  return new Promise<RenderSuspendeResult>((resolve, reject) => {
-    let isMountSettled = false
-    const utils = renderFromTestingLibrary(
-      {
-        __cssModules: componentRest.__cssModules,
-        inheritAttrs: false,
-        setup: (props: Record<string, unknown>, ctx: SetupContext) => {
-          patchInstanceAppContext()
 
-          wrappedInstance = getCurrentInstance()
-          setupContext = ctx
-
-          const scope = effectScope()
-
-          window.__cleanup ||= []
-          window.__cleanup.push(() => {
-            scope.stop()
-          })
-
-          const nuxtRootSetupResult = scope.run(() => NuxtRoot.setup(props, {
-            ...ctx,
-            expose: () => ({}),
-          }))
-
-          onErrorCaptured((error, ...args) => {
-            if (isMountSettled) return
-            isMountSettled = true
-            try {
-              wrappedInstance?.appContext.config.errorHandler?.(error, ...args)
-              reject(error)
-            }
-            catch (error) {
-              reject(error)
-            }
-            return false
-          })
-
-          return nuxtRootSetupResult
-        },
-        render: () =>
-          // See discussions in https://github.com/testing-library/vue-testing-library/issues/230
-          // we add this additional root element because otherwise testing-library breaks
-          // because there's no root element while Suspense is resolving
-          h(
-            WrapperComponent,
-            {},
-            {
-              default: () => h(
-                Suspense,
-                {
-                  onResolve: () =>
-                    nextTick().then(() => {
-                      if (isMountSettled) return
-                      isMountSettled = true;
-                      (utils as unknown as AugmentedVueInstance).setupState = setupState
-                      utils.rerender = async (props) => {
-                        Object.assign(setProps, props)
-                        await nextTick()
-                      }
-                      resolve(utils as RenderSuspendeResult)
-                    }),
-                },
-                {
-                  default: () =>
-                    h({
-                      name: 'RenderHelper',
-                      render: () => '',
-                      async setup() {
-                        const router = useRouter()
-                        await router.replace(route)
-
-                        // Proxy top-level setup/render context so test wrapper resolves child component
-                        const clonedComponent = {
-                          components: {},
-                          ...component,
-                          name: 'RenderSuspendedComponent',
-                          render: render,
-                          setup: (props: Record<string, unknown>, ctx: SetupContext) =>
-                            wrappedSetup(props, setupContext, ctx),
-                        }
-
-                        return () => h(clonedComponent, { ...(props && typeof props === 'object' ? props : {}), ...setProps, ...attrs }, setupContext.slots)
-                      },
-                    }),
-                },
-              ),
-            },
-          ),
-      },
-      defu(_options, {
-        props: props as object,
-        slots,
-        attrs,
-        global: {
-          config: {
-            globalProperties: {
-              ...vueApp.config.globalProperties,
-              // make all properties/keys enumerable.
-              ...Object.fromEntries(
-                Object.getOwnPropertyNames(vueApp.config.globalProperties)
-                  .map(key => [key, vueApp.config.globalProperties[key]]),
-              ),
-            },
-          },
-          directives: vueApp._context.directives,
-          provide: vueApp._context.provides,
-          components: { RouterLink },
-        },
-      }),
-    )
-  })
-}
-
-declare global {
-  interface Window {
-    __cleanup?: Array<() => void>
+  wrapper.rerender = async (props) => {
+    setProps(props)
+    await nextTick()
   }
-}
 
-interface AugmentedVueInstance {
-  setupState?: SetupState
+  return wrapper
 }

--- a/src/runtime-utils/utils/suspended.ts
+++ b/src/runtime-utils/utils/suspended.ts
@@ -1,0 +1,225 @@
+import { Suspense, effectScope, h, nextTick, reactive, getCurrentInstance, onErrorCaptured } from 'vue'
+import type { App, ComponentInternalInstance, DefineComponent, SetupContext, VNode } from 'vue'
+import { defu } from 'defu'
+import type { RouteLocationRaw } from 'vue-router'
+import type { ComponentMountingOptions } from '@vue/test-utils'
+
+import { tryUseNuxtApp, useRouter } from '#imports'
+import NuxtRoot from '#build/root-component.mjs'
+
+import { RouterLink } from '../components/RouterLink'
+
+// TODO: improve return types
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SetupState = Record<string, any>
+
+type BaseOptions<C> = Pick<ComponentMountingOptions<C>, 'global'>
+
+type WrapperFn<C> = (c: C, o?: BaseOptions<C>) => unknown
+type WrapperFnComponent<Fn> = Fn extends (c: infer C, o: infer _) => infer _ ? C : never
+type WrapperFnOption<Fn> = Fn extends (c: WrapperFnComponent<Fn>, o: infer O) => infer _ ? O : never
+type WrapperFnResult<Fn> = Fn extends (c: WrapperFnComponent<Fn>, o: WrapperFnOption<Fn>) => infer R ? R : never
+
+export type WrapperSuspendedOptions<Fn> = WrapperFnOption<Fn> & {
+  route?: RouteLocationRaw
+  scoped?: boolean
+}
+
+export type WrapperSuspendedResult<Fn> = WrapperFnResult<Fn> & {
+  setupState: SetupState
+}
+
+export function cleanupAll() {
+  for (const fn of (window.__cleanup || []).splice(0)) {
+    fn()
+  }
+}
+
+export function addCleanup(fn: () => unknown) {
+  window.__cleanup ||= []
+  window.__cleanup.push(fn)
+}
+
+function runEffectScope<T>(fn: () => T) {
+  const scope = effectScope()
+  addCleanup(() => scope.stop())
+  return scope.run(fn)
+}
+
+export function wrapperSuspended<C, Fn extends WrapperFn<C>>(
+  component: C,
+  options: WrapperSuspendedOptions<Fn>,
+  {
+    wrapperFn,
+    wrappedRender = fn => fn,
+    suspendedHelperName,
+    clonedComponentName,
+  }: {
+    wrapperFn: NonNullable<Fn>
+    wrappedRender?: (render: () => VNode) => () => VNode
+    suspendedHelperName: string
+    clonedComponentName: string
+  },
+): Promise<{
+  wrapper: WrapperSuspendedResult<Fn>
+  setProps: (props: object) => void
+}> {
+  const { props = {}, attrs = {} } = options as ComponentMountingOptions<C>
+  const { route = '/', scoped = false, ...wrapperFnOptions } = options
+
+  const vueApp: App<Element> & Record<string, unknown> = tryUseNuxtApp()?.vueApp
+    // @ts-expect-error untyped global __unctx__
+    || globalThis.__unctx__.get('nuxt-app').tryUse().vueApp
+  const {
+    render: componentRender,
+    setup: componentSetup,
+    ...componentRest
+  } = component as DefineComponent<Record<string, unknown>, Record<string, unknown>>
+
+  let wrappedInstance: ComponentInternalInstance | null = null
+  let setupContext: SetupContext
+  let setupState: SetupState
+
+  const setProps = reactive<Record<string, unknown>>({})
+
+  function patchInstanceAppContext() {
+    const app = getCurrentInstance()?.appContext.app as typeof vueApp
+    if (!app) return
+
+    for (const [key, value] of Object.entries(vueApp)) {
+      if (key in app) continue
+      app[key] = value
+    }
+  }
+
+  const ClonedComponent = {
+    components: {},
+    ...component,
+    name: clonedComponentName,
+    async setup(props: Record<string, unknown>, instanceContext: SetupContext) {
+      const currentInstance = getCurrentInstance()
+      if (currentInstance) {
+        currentInstance.emit = (event, ...args) => {
+          setupContext.emit(event, ...args)
+        }
+      }
+
+      if (!componentSetup) return
+
+      const result = scoped
+        ? await runEffectScope(() => componentSetup(props, setupContext))
+        : await componentSetup(props, setupContext)
+
+      if (wrappedInstance?.exposed) {
+        instanceContext.expose(wrappedInstance.exposed)
+      }
+
+      setupState = result && typeof result === 'object' ? result : {}
+
+      return result
+    },
+  }
+
+  const SuspendedHelper = {
+    name: suspendedHelperName,
+    render: () => '',
+    async setup() {
+      const router = useRouter()
+      await router.replace(route)
+      return () => h(ClonedComponent, { ...props, ...setProps, ...attrs }, setupContext.slots)
+    },
+  }
+
+  return new Promise((resolve, reject) => {
+    let isMountSettled = false
+
+    const wrapper = wrapperFn(
+      {
+        inheritAttrs: false,
+        __cssModules: componentRest.__cssModules,
+        setup: (props: Record<string, unknown>, ctx: SetupContext) => {
+          patchInstanceAppContext()
+
+          wrappedInstance = getCurrentInstance()
+          setupContext = ctx
+
+          const nuxtRootSetupResult = runEffectScope(
+            () => NuxtRoot.setup(props, {
+              ...ctx,
+              expose: () => {},
+            }),
+          )
+
+          onErrorCaptured((error, ...args) => {
+            if (isMountSettled) return
+            isMountSettled = true
+            try {
+              wrappedInstance?.appContext.config.errorHandler?.(error, ...args)
+              reject(error)
+            }
+            catch (error) {
+              reject(error)
+            }
+            return false
+          })
+
+          return nuxtRootSetupResult
+        },
+        render: wrappedRender(() => h(
+          Suspense,
+          {
+            onResolve: () =>
+              nextTick().then(() => {
+                if (isMountSettled) return
+                isMountSettled = true
+
+                wrapper.setupState = setupState
+
+                resolve({
+                  wrapper,
+                  setProps: (props) => {
+                    Object.assign(setProps, props)
+                  },
+                })
+              }),
+          },
+          {
+            default: () => h(SuspendedHelper),
+          },
+        )),
+      } as C,
+      defu(wrapperFnOptions, {
+        global: {
+          config: {
+            globalProperties: makeAllPropertiesEnumerable(
+              vueApp.config.globalProperties,
+            ),
+          },
+          directives: vueApp._context.directives,
+          provide: vueApp._context.provides,
+          stubs: {
+            Suspense: false,
+            [SuspendedHelper.name]: false,
+            [ClonedComponent.name]: false,
+          },
+          components: { ...vueApp._context.components, RouterLink },
+        },
+      } satisfies ComponentMountingOptions<C>),
+    ) as WrapperSuspendedResult<Fn>
+  })
+}
+
+function makeAllPropertiesEnumerable<V, T extends Record<string, V>>(target: T) {
+  return {
+    ...target,
+    ...Object.fromEntries(
+      Object.getOwnPropertyNames(target).map(key => [key, target[key]]),
+    ),
+  } as T
+}
+
+declare global {
+  interface Window {
+    __cleanup?: Array<() => void>
+  }
+}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Unified the underlying logic of the `mountSuspended` and `renderSuspended`.
This also fixes the missing setup logic for vueApp.context.components in renderSuspended.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
