### PR TITLE
feat(module): devtools vitest run in separate process

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -11,6 +11,7 @@ export default defineBuildConfig({
     'src/config',
     'src/module.ts',
     'src/vitest-environment',
+    'src/vitest-wrapper/cli.ts',
     isStub ? { input: 'src/runtime-utils/', outDir: 'dist/runtime-utils', format: 'esm' } : 'src/runtime-utils/index.mjs',
     { input: 'src/runtime/', outDir: 'dist/runtime', format: 'esm' },
   ],

--- a/examples/app-vitest-full/package.json
+++ b/examples/app-vitest-full/package.json
@@ -8,7 +8,7 @@
     "dev:prepare": "nuxt prepare",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "test:dev": "NUXT_VITEST_DEV_TEST=true nuxt dev --no-fork",
+    "test:dev": "nuxt dev --no-fork",
     "test:unit": "vitest",
     "test:types": "nuxi prepare && vue-tsc --noEmit",
     "test:jsdom": "VITEST_DOM_ENV=jsdom pnpm test:unit --run",

--- a/examples/app-vitest-full/tests/nuxt/render-suspended.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/render-suspended.spec.ts
@@ -33,13 +33,7 @@ const formats = {
 
 describe('renderSuspended', () => {
   afterEach(() => {
-    // since we're not running with Vitest globals when running the tests
-    // from inside the test server. This means testing-library cannot
-    // auto-attach the cleanup go testing globals, and we have to do
-    // it here manually.
-    if (process.env.NUXT_VITEST_DEV_TEST) {
-      cleanup()
-    }
+    cleanup()
   })
 
   it('can render components within nuxt suspense', async () => {

--- a/examples/app-vitest-full/tests/resolved-files.spec.ts
+++ b/examples/app-vitest-full/tests/resolved-files.spec.ts
@@ -2,8 +2,7 @@ import { fileURLToPath } from 'node:url'
 import { test, expect } from 'vitest'
 import { createVitest } from 'vitest/node'
 
-// TODO: Investigate why this test fails when executed by the dev server. Once it's fixed, we can reenable this test.
-test.skipIf(process.env.NUXT_VITEST_DEV_TEST)('it should include nuxt spec files', { timeout: 30000 }, async () => {
+test('it should include nuxt spec files', { timeout: 30000 }, async () => {
   const vitest = await createVitest('test', {
     config: fileURLToPath(new URL('../vitest.config.ts', import.meta.url)),
     dir: fileURLToPath(new URL('../', import.meta.url)),

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ import { defineConfig } from 'vite'
 import type { TestProjectInlineConfiguration } from 'vitest/config'
 import { setupDotenv } from 'c12'
 import type { DotenvOptions } from 'c12'
-import type { UserConfig as ViteUserConfig } from 'vite'
+import type { UserConfigFnPromise, UserConfig as ViteUserConfig } from 'vite'
 import type { DateString } from 'compatx'
 import { defu } from 'defu'
 import { createResolver, findPath } from '@nuxt/kit'
@@ -119,7 +119,6 @@ export async function getVitestConfigFromNuxt(
         noDiscovery: true,
       },
       test: {
-        dir: process.cwd(),
         environmentOptions: {
           nuxtRuntimeConfig: applyEnv(structuredClone(options.nuxt.options.runtimeConfig), {
             prefix: 'NUXT_',
@@ -224,10 +223,7 @@ export async function getVitestConfigFromNuxt(
   return resolvedConfig
 }
 
-export async function defineVitestProject(config: TestProjectInlineConfiguration) {
-  // When Nuxt module calls `startVitest`, we don't need to call `getVitestConfigFromNuxt` again
-  if (process.env.__NUXT_VITEST_RESOLVED__) return config
-
+export async function defineVitestProject(config: TestProjectInlineConfiguration): Promise<TestProjectInlineConfiguration> {
   const resolvedConfig = await resolveConfig(config)
 
   resolvedConfig.test.environment = 'nuxt'
@@ -235,11 +231,8 @@ export async function defineVitestProject(config: TestProjectInlineConfiguration
   return resolvedConfig
 }
 
-export function defineVitestConfig(config: ViteUserConfig & { test?: VitestConfig } = {}) {
+export function defineVitestConfig(config: ViteUserConfig & { test?: VitestConfig } = {}): UserConfigFnPromise {
   return defineConfig(async () => {
-    // When Nuxt module calls `startVitest`, we don't need to call `getVitestConfigFromNuxt` again
-    if (process.env.__NUXT_VITEST_RESOLVED__) return config
-
     const resolvedConfig = await resolveConfig(config)
 
     if (resolvedConfig.test.browser?.enabled) {

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -1,0 +1,136 @@
+import { h } from 'vue'
+import { defineEventHandler } from 'h3'
+import { provider } from 'std-env'
+import { debounce } from 'perfect-debounce'
+import { addDevServerHandler, useNuxt } from '@nuxt/kit'
+import type { ModuleCustomTab } from '@nuxt/devtools-kit/types'
+
+import type { VitestWrapper } from './vitest-wrapper/host'
+
+export async function setupDevTools(
+  vitestWrapper: VitestWrapper,
+  nuxt = useNuxt(),
+) {
+  const iframeSrc = '/__test_utils_vitest__/'
+
+  const updateTabs = debounce(() => {
+    nuxt.callHook('devtools:customTabs:refresh')
+  }, 100)
+
+  nuxt.hook('devtools:customTabs', (tabs) => {
+    const tab = createVitestCustomTab(vitestWrapper, { iframeSrc })
+    const index = tabs.findIndex(({ name }) => tab.name === name)
+    if (index === -1) {
+      tabs.push(tab)
+    }
+    else {
+      tabs.splice(index, 1, tab)
+    }
+  })
+
+  addDevServerHandler({
+    route: iframeSrc,
+    handler: defineEventHandler(
+      () => iframeContentHtml(vitestWrapper.uiUrl),
+    ),
+  })
+
+  vitestWrapper.ons({
+    started() {
+      updateTabs()
+    },
+    updated() {
+      updateTabs()
+    },
+    finished() {
+      updateTabs()
+    },
+    exited() {
+      updateTabs()
+    },
+  })
+}
+
+function createVitestCustomTab(
+  vitest: VitestWrapper,
+  { iframeSrc }: { iframeSrc: string },
+) {
+  const launchView: ModuleCustomTab['view'] = {
+    type: 'launch',
+    description: 'Start tests along with Nuxt',
+    actions: [
+      {
+        get label() {
+          switch (vitest.status) {
+            case 'starting': return 'Starting...'
+            case 'running': return 'Running Vitest'
+            case 'stopped': return 'Start Vitest'
+            case 'finished': return 'Start Vitest'
+          }
+        },
+        get pending() {
+          return vitest.status === 'starting' || vitest.status === 'running'
+        },
+        handle: () => {
+          vitest.start()
+        },
+      },
+    ],
+  }
+
+  const uiView: ModuleCustomTab['view'] = {
+    type: 'iframe',
+    persistent: false,
+    src: iframeSrc,
+  }
+
+  const tab: ModuleCustomTab = {
+    title: 'Vitest',
+    name: 'vitest',
+    icon: 'logos-vitest',
+    get view() {
+      if (vitest.status === 'stopped' || vitest.status === 'starting' || !vitest.uiUrl) {
+        return launchView
+      }
+      else {
+        return uiView
+      }
+    },
+    extraTabVNode: vitest.testSummary.totalCount
+      ? h('div', { style: { color: vitest.testSummary.failedCount ? 'orange' : 'green' } }, [
+          h('span', {}, vitest.testSummary.passedCount),
+          h('span', { style: { opacity: '0.5', fontSize: '0.9em' } }, '/'),
+          h(
+            'span',
+            { style: { opacity: '0.8', fontSize: '0.9em' } },
+            vitest.testSummary.totalCount,
+          ),
+        ])
+      : undefined,
+  }
+
+  return tab
+}
+
+function iframeContentHtml(uiUrl: string | undefined) {
+  return [
+    '<html><head><script>',
+    `(${function redirect(uiUrl: string, provider: string) {
+      if (typeof window === 'undefined') return
+
+      if (!uiUrl) return
+
+      if (provider === 'stackblitz') {
+        const url = new URL(window.location.href)
+        const newUrl = new URL(uiUrl)
+        newUrl.host = url.host.replace(/--\d+--/, `--${newUrl.port}--`)
+        newUrl.protocol = url.protocol
+        newUrl.port = url.port
+        uiUrl = newUrl.toString()
+      }
+
+      window.location.replace(uiUrl)
+    }})(${JSON.stringify(uiUrl)}, ${JSON.stringify(provider)})`,
+    '</script></head></html>',
+  ].join('\n')
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,34 +1,19 @@
-/// <reference types="@nuxt/devtools-kit" />
-
-import { pathToFileURL } from 'node:url'
-import { createResolver, defineNuxtModule, logger, resolvePath, importModule } from '@nuxt/kit'
-import type { Vitest, UserConfig as VitestConfig } from 'vitest/node'
-import type { Reporter } from 'vitest/reporters'
-import type { RunnerTestFile } from 'vitest'
-import type { InlineConfig as ViteConfig } from 'vite'
-import { getPort } from 'get-port-please'
-import { h } from 'vue'
-import { debounce } from 'perfect-debounce'
-import { isCI } from 'std-env'
-import { defu } from 'defu'
+import { createResolver, defineNuxtModule, logger, resolvePath, useNuxt } from '@nuxt/kit'
+import type { UserConfig as VitestConfig } from 'vitest/node'
 import { join, relative } from 'pathe'
+import { isCI } from 'std-env'
 
-import { getVitestConfigFromNuxt } from './config'
 import { setupImportMocking } from './module/mock'
 import { NuxtRootStubPlugin } from './module/plugins/entry'
 import { loadKit } from './utils'
+import { setupDevTools } from './devtools'
+import { vitestWrapper } from './vitest-wrapper/host'
 
 export interface NuxtVitestOptions {
   startOnBoot?: boolean
   logToConsole?: boolean
   vitestConfig?: VitestConfig
 }
-
-/**
- * List of plugins that are not compatible with test env.
- * Hard-coded for now, should remove by PR to upstream.
- */
-const vitePluginBlocklist = ['vite-plugin-vue-inspector', 'vite-plugin-vue-inspector:post', 'vite-plugin-inspect', 'nuxt:type-check']
 
 export default defineNuxtModule<NuxtVitestOptions>({
   meta: {
@@ -76,153 +61,52 @@ export default defineNuxtModule<NuxtVitestOptions>({
     // the nuxt instance is used by a standalone Vitest env, we skip this module
     if (process.env.TEST || process.env.VITE_TEST) return
 
-    const rawViteConfigPromise = new Promise<ViteConfig>((resolve) => {
-      // Wrap with app:resolve to ensure we got the final vite config
-      nuxt.hook('app:resolve', () => {
-        nuxt.hook('vite:configResolved', (config, { isClient }) => {
-          if (isClient) resolve(config)
-        })
-      })
-    })
+    const vitestWrapper = createVitestWrapper(options, nuxt)
 
-    let loaded = false
-    let promise: Promise<void> | undefined
-    let ctx: Vitest = undefined!
-    let testFiles: RunnerTestFile[] | null = null
+    const isDevToolsEnabled = typeof nuxt.options.devtools === 'boolean'
+      ? nuxt.options.devtools
+      : nuxt.options.devtools.enabled
 
-    const updateTabs = debounce(() => {
-      nuxt.callHook('devtools:customTabs:refresh')
-    }, 100)
-
-    let URL: string
-
-    async function start() {
-      const { mergeConfig } = await importModule<typeof import('vite')>('vite', { paths: nuxt.options.modulesDir })
-      const rawViteConfig = mergeConfig({}, await rawViteConfigPromise)
-
-      const viteConfig = await getVitestConfigFromNuxt({ nuxt, viteConfig: defu({ test: options.vitestConfig }, rawViteConfig) })
-
-      viteConfig.plugins = (viteConfig.plugins || []).filter((p) => {
-        return !p || !('name' in p) || !vitePluginBlocklist.includes(p.name)
-      })
-
-      // TODO: investigate why this is needed
-      viteConfig.test.environmentMatchGlobs ||= []
-      viteConfig.test.environmentMatchGlobs.push(
-        ['**/*.nuxt.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}', 'nuxt'],
-        ['{test,tests}/nuxt/**.*', 'nuxt'],
-      )
-
-      process.env.__NUXT_VITEST_RESOLVED__ = 'true'
-      const { startVitest } = (await import(pathToFileURL(await resolvePath('vitest/node')).href)) as typeof import('vitest/node')
-
-      const customReporter: Reporter = {
-        onInit(_ctx) {
-          ctx = _ctx
-        },
-        onTaskUpdate() {
-          testFiles = ctx.state.getFiles()
-          updateTabs()
-        },
-        onFinished() {
-          testFiles = ctx.state.getFiles()
-          updateTabs()
-        },
-      }
-
-      const watchMode = !process.env.NUXT_VITEST_DEV_TEST && !isCI
-
-      // We resolve the path here to ensure the dev server is already running with the correct protocol
-      const PORT = await getPort({ port: 15555 })
-      const PROTOCOL = nuxt.options.devServer.https ? 'https' : 'http'
-      URL = `${PROTOCOL}://localhost:${PORT}/__vitest__/`
-
-      // For testing dev mode in CI, maybe expose an option to user later
-      const overrides: VitestConfig = watchMode
-        ? {
-            passWithNoTests: true,
-            reporters: options.logToConsole
-              ? [
-                  ...toArray(options.vitestConfig?.reporters ?? ['default']),
-                  customReporter,
-                ]
-              : [customReporter], // do not report to console
-            watch: true,
-            ui: true,
-            open: false,
-            api: {
-              port: PORT,
-            },
-          }
-        : { watch: false }
-
-      // Start Vitest
-      const promise = startVitest('test', [], defu(overrides, viteConfig.test), viteConfig)
-      promise.catch(() => process.exit(1))
-
-      if (watchMode) {
-        logger.info(`Vitest UI starting on ${URL}`)
-        nuxt.hook('close', () => promise.then(v => v?.close()))
-        await new Promise(resolve => setTimeout(resolve, 1000))
-      }
-      else {
-        promise.then(v => nuxt.close().then(() => v?.close()).then(() => process.exit()))
-      }
-
-      loaded = true
+    if (isDevToolsEnabled) {
+      await setupDevTools(vitestWrapper, nuxt)
     }
 
-    nuxt.hook('devtools:customTabs', (tabs) => {
-      const failedCount
-        = testFiles?.filter(f => f.result?.state === 'fail').length ?? 0
-      const passedCount
-        = testFiles?.filter(f => f.result?.state === 'pass').length ?? 0
-      const totalCount = testFiles?.length ?? 0
-
-      tabs.push({
-        title: 'Vitest',
-        name: 'vitest',
-        icon: 'logos-vitest',
-        view: loaded
-          ? {
-              type: 'iframe',
-              src: URL,
-            }
-          : {
-              type: 'launch',
-              description: 'Start tests along with Nuxt',
-              actions: [
-                {
-                  label: promise ? 'Starting...' : 'Start Vitest',
-                  pending: !!promise,
-                  handle: () => {
-                    promise = promise || start()
-                    return promise
-                  },
-                },
-              ],
-            },
-        extraTabVNode: totalCount
-          ? h('div', { style: { color: failedCount ? 'orange' : 'green' } }, [
-              h('span', {}, passedCount),
-              h('span', { style: { opacity: '0.5', fontSize: '0.9em' } }, '/'),
-              h(
-                'span',
-                { style: { opacity: '0.8', fontSize: '0.9em' } },
-                totalCount,
-              ),
-            ])
-          : undefined,
-      })
-    })
-
     if (options.startOnBoot) {
-      promise = promise || start()
-      promise.then(updateTabs)
+      vitestWrapper.start()
     }
   },
 })
 
-function toArray<T>(value: T | T[]): T[] {
-  return Array.isArray(value) ? value : [value]
+function createVitestWrapper(options: NuxtVitestOptions, nuxt = useNuxt()) {
+  const watchMode = !isCI
+
+  const wrapper = vitestWrapper({
+    cwd: nuxt.options.rootDir,
+    apiPorts: [15555],
+    logToConsole: options.logToConsole ?? false,
+    watchMode,
+  })
+
+  wrapper.ons({
+    started({ uiUrl }) {
+      if (watchMode) {
+        logger.info(`Vitest UI starting on ${uiUrl}`)
+      }
+    },
+    exited({ exitCode }) {
+      if (watchMode) {
+        logger.info(`Vitest exited with code ${exitCode}`)
+      }
+      else {
+        nuxt.close().finally(() => process.exit(exitCode))
+      }
+    },
+  })
+
+  nuxt.hooks.addHooks({
+    close: () => wrapper.stop(),
+    restart: () => wrapper.stop(),
+  })
+
+  return wrapper
 }

--- a/src/vitest-wrapper/cli.ts
+++ b/src/vitest-wrapper/cli.ts
@@ -1,0 +1,103 @@
+import type { Vitest, Reporter } from 'vitest/node'
+import { importModule } from 'local-pkg'
+import { getPort } from 'get-port-please'
+
+import {
+  sendMessageToHost as sendMessage,
+  listenHostMessages as listenMessages,
+} from './interface'
+import type {
+  SendToCliMessage as RecieveMessage,
+  SendToHostMessage as SendMessage,
+} from './interface'
+
+function createCustomReporter(onVitestInit: (ctx: Vitest) => unknown): Reporter {
+  let ctx: Vitest = undefined!
+
+  function getVitestUiUrl() {
+    if (!ctx.config.ui) return undefined
+    const protocol = ctx.vite.config.server.https ? 'https:' : 'http:'
+    const host = ctx.config.api.host || 'localhost'
+    const port = ctx.config.api.port
+    const uiBase = ctx.config.uiBase
+    return `${protocol}//${host}:${port}${uiBase}`
+  }
+
+  function toUpdatedResult(): SendMessage['updated'] {
+    const files = ctx.state.getFiles()
+    return {
+      failedCount: files.filter(f => f.result?.state === 'fail').length ?? 0,
+      passedCount: files.filter(f => f.result?.state === 'pass').length ?? 0,
+      totalCount: files.length ?? 0,
+    }
+  }
+
+  function toFinishedResult(): SendMessage['finished'] {
+    return toUpdatedResult()
+  }
+
+  return {
+    onInit(_ctx) {
+      ctx = _ctx
+      onVitestInit(ctx)
+      sendMessage('started', { uiUrl: getVitestUiUrl() })
+    },
+
+    onTestRunStart() {
+      sendMessage('updated', toUpdatedResult())
+    },
+
+    onTaskUpdate() {
+      sendMessage('updated', toUpdatedResult())
+    },
+
+    onFinished() {
+      sendMessage('finished', toFinishedResult())
+    },
+  }
+}
+
+async function main() {
+  const {
+    apiPorts,
+    watchMode,
+  } = await new Promise<RecieveMessage['start']>((resolve) => {
+    listenMessages(({ type, payload }) => {
+      if (type === 'start') resolve(payload)
+    })
+  })
+
+  const port = apiPorts ? await getPort({ ports: apiPorts }) : undefined
+
+  const { startVitest } = await importModule<typeof import('vitest/node')>('vitest/node')
+
+  const customReporter = createCustomReporter((vitest) => {
+    listenMessages(async ({ type, payload }) => {
+      if (type === 'stop') {
+        await vitest.exit(payload.force)
+        process.exit()
+      }
+    })
+  })
+
+  const vitest = await startVitest('test', [], watchMode
+    ? {
+        passWithNoTests: true,
+        ui: true,
+        watch: true,
+        open: false,
+        api: { port },
+      }
+    : { ui: false, watch: false }, {
+    test: {
+      reporters: ['default', customReporter],
+    },
+  })
+
+  if (!watchMode) {
+    await vitest.exit()
+    process.exit()
+  }
+}
+
+main()

--- a/src/vitest-wrapper/host.ts
+++ b/src/vitest-wrapper/host.ts
@@ -1,0 +1,131 @@
+import { resolve } from 'pathe'
+import { fork } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
+
+import {
+  sendMessageToCli as sendMessage,
+  listenCliMessages as listenMessages,
+  createVitestTestSummary,
+} from './interface'
+import type {
+  SendToCliMessage as SendMessage,
+  SendToHostMessage as RecieveMessage,
+} from './interface'
+
+import { distDir } from '#dirs'
+
+type Handlers = {
+  [K in keyof RecieveMessage]: ((payload: RecieveMessage[K]) => unknown)[]
+} & {
+  exited: ((payload: { exitCode: number }) => unknown)[]
+}
+
+export type VitestWrapper = ReturnType<typeof vitestWrapper>
+
+export function vitestWrapper(
+  options: SendMessage['start'] & { cwd: string },
+) {
+  const { cwd, ...startOptions } = options
+
+  let _status = 'stopped' as 'stopped' | 'starting' | 'running' | 'finished'
+  let _uiUrl: string | undefined
+  let _process: ChildProcess | undefined
+  let _testSummary = createVitestTestSummary()
+
+  const _handlers: Handlers = {
+    started: [({ uiUrl }) => {
+      _uiUrl = uiUrl
+      _status = 'running'
+      _testSummary = createVitestTestSummary()
+    }],
+    updated: [(summary) => {
+      _testSummary = summary
+    }],
+    finished: [(summary) => {
+      _status = 'finished'
+      _testSummary = summary
+    }],
+    exited: [clear],
+  }
+
+  function clear() {
+    _status = 'stopped'
+    _uiUrl = undefined
+    _process = undefined
+    _testSummary = createVitestTestSummary()
+  }
+
+  function on(name: keyof Handlers, handler: NonNullable<Handlers[typeof name]>[number]) {
+    _handlers[name] ??= []
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    _handlers[name]?.push(handler as any)
+  }
+
+  function ons(handlers: { [K in keyof Handlers]?: NonNullable<Handlers[K]>[number] }) {
+    for (const [name, handler] of Object.entries(handlers)) {
+      if (typeof handler === 'function') {
+        on(name as keyof Handlers, handler)
+      }
+    }
+  }
+
+  async function stop() {
+    const vitest = _process
+    if (!vitest || vitest.exitCode !== null) return
+    return new Promise<void>((resolve) => {
+      vitest.once('exit', () => resolve())
+      sendMessage(vitest, 'stop', { force: true })
+    })
+  }
+
+  async function start() {
+    if (_process) return false
+
+    const vitest = fork(resolve(distDir, './vitest-wrapper/cli.mjs'), {
+      cwd,
+      env: {
+        ...process.env,
+        NODE_ENV: 'test',
+        MODE: 'test',
+      },
+      stdio: startOptions.logToConsole
+        ? undefined
+        : ['ignore', 'ignore', 'inherit', 'ipc'],
+    })
+
+    _status = 'starting'
+    _process = vitest
+
+    vitest.once('exit', () => {
+      _handlers.exited.forEach(fn => fn({ exitCode: vitest.exitCode ?? 0 }))
+    })
+
+    listenMessages(vitest, ({ type, payload }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      _handlers[type].forEach(fn => fn(payload as any))
+    })
+
+    sendMessage(vitest, 'start', startOptions)
+
+    return true
+  }
+
+  return {
+    on,
+    ons,
+    stop,
+    start,
+    get uiUrl() {
+      return _uiUrl
+    },
+    get options() {
+      return options
+    },
+    get status() {
+      return _status
+    },
+    get testSummary() {
+      return { ..._testSummary }
+    },
+  }
+}

--- a/src/vitest-wrapper/interface.ts
+++ b/src/vitest-wrapper/interface.ts
@@ -1,0 +1,80 @@
+import type { ChildProcess } from 'node:child_process'
+
+export type VitestTestSummary = {
+  failedCount: number
+  passedCount: number
+  totalCount: number
+}
+
+export type SendToHostMessage = {
+  started: {
+    uiUrl: string | undefined
+  }
+  updated: VitestTestSummary
+  finished: VitestTestSummary
+}
+
+export type SendToCliMessage = {
+  start: {
+    watchMode: boolean
+    apiPorts?: number[]
+    logToConsole?: boolean
+  }
+  stop: {
+    force?: boolean
+  }
+}
+
+type ToMessage<T, K extends keyof T> = { type: K, payload: T[K] }
+type ToMessages<T> = { [K in keyof T]: ToMessage<T, K> }[keyof T]
+
+function isMessage<T>(message: unknown): message is T {
+  return message !== null
+    && typeof message === 'object'
+    && 'type' in message && message.type !== null && typeof message.type === 'string'
+    && 'payload' in message && message.payload !== null && typeof message.payload === 'object'
+}
+
+export function createVitestTestSummary(): VitestTestSummary {
+  return {
+    failedCount: 0,
+    passedCount: 0,
+    totalCount: 0,
+  }
+}
+
+export function sendMessageToHost<K extends keyof SendToHostMessage>(
+  type: K,
+  payload: SendToHostMessage[K],
+) {
+  process.send?.({ type, payload })
+}
+
+export function listenHostMessages(
+  listener: (message: ToMessages<SendToCliMessage>) => unknown,
+) {
+  process.on('message', (message) => {
+    if (isMessage<ToMessages<SendToCliMessage>>(message)) {
+      listener(message)
+    }
+  })
+}
+
+export function sendMessageToCli<K extends keyof SendToCliMessage>(
+  cli: ChildProcess,
+  type: K,
+  payload: SendToCliMessage[K],
+) {
+  cli.send({ type, payload })
+}
+
+export function listenCliMessages(
+  cli: ChildProcess,
+  listener: (message: ToMessages<SendToHostMessage>) => unknown,
+) {
+  cli.on('message', (message) => {
+    if (isMessage<ToMessages<SendToHostMessage>>(message)) {
+      listener(message)
+    }
+  })
+}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

resolves #989, resolves #837, resolves #502

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

devtool now delegates config loading to startVitest instead of using the currently loaded viteConfig.

### Reproductions

vitest ui can now be displayed within the devtools iframe on stackblitz

* [stackblitz for issue 989](https://stackblitz.com/edit/nuxt-starter-5frpe9ah?file=package.json)
  * act: start vitest via the devtools
  * expected: tests/app.spec.ts is executed in the nuxt test environment
* [stackblitz for issue 837](https://stackblitz.com/edit/nuxt-starter-9bvfeflk?file=package.json)
  * act: start vitest via the devtools
  * expected: vitest.config.ts is used and the test e2e/dummy.test.ts is not executed

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
