### PR TITLE
feat(runtime): skip route sync emulation when `NuxtPage` exists

### DIFF
--- a/examples/app-vitest-full/tests/nuxt/vue-wrapper-plugin.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/vue-wrapper-plugin.spec.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, it, expect } from 'vitest'
+import { enableAutoUnmount, config } from '@vue/test-utils'
+import { mountSuspended, renderSuspended } from '@nuxt/test-utils/runtime'
+
+import type { Component, DefineComponent } from 'vue'
+
+import { NuxtLayout, NuxtPage } from '#components'
+
+import App from '~/app.vue'
+
+describe('vue-wrapper-plugin', () => {
+  const wrapperFns = [
+    mountSuspended,
+    renderSuspended,
+  ].map(wrapperFn => ({ wrapperFn, wrapperFnName: wrapperFn.name }))
+
+  describe('hasNuxtPage', () => {
+    enableAutoUnmount(afterEach)
+
+    const components: ReadonlyArray<Component | DefineComponent> = [
+      { name: 'App', ...App },
+      { name: 'setup1', setup: () => () => h(NuxtPage) },
+      { name: 'setup2', setup: () => () => h(NuxtLayout, {}, () => h(NuxtPage)) },
+      { name: 'render1', render: () => h(NuxtLayout, {}, () => h(NuxtPage)) },
+    ]
+
+    it.each(wrapperFns.flatMap(
+      ({ wrapperFn, wrapperFnName }) => components.map(Component => ({
+        wrapperFnName,
+        wrapperFn,
+        Component,
+        componentName: Component.name,
+      }))),
+    )('should return true if <NuxtPage> is exists $wrapperFnName $componentName',
+      async ({ wrapperFn, Component }) => {
+        expect(hasNuxtPage()).toBe(false)
+        await wrapperFn(Component)
+        expect(hasNuxtPage()).toBe(true)
+      })
+
+    it.each(wrapperFns)(
+      'should return false if <NuxtPage> is unmounted $wrapperFnName',
+      async ({ wrapperFn }) => {
+        expect(hasNuxtPage()).toBe(false)
+        const wrapper = await wrapperFn(
+          { setup: () => () => h(NuxtPage) },
+        )
+        expect(hasNuxtPage()).toBe(true)
+        wrapper.unmount()
+        expect(hasNuxtPage()).toBe(false)
+      })
+
+    it.each(wrapperFns)(
+      'should return false if <NuxtPage> is not exists $wrapperFnName',
+      async ({ wrapperFn }) => {
+        expect(hasNuxtPage()).toBe(false)
+        await wrapperFn(
+          { setup: () => () => h('div') },
+        )
+        expect(hasNuxtPage()).toBe(false)
+      })
+  })
+
+  function getVueWrapperPlugin() {
+    const plugins = config.plugins.VueWrapper.installedPlugins
+    return plugins.find(
+      ({ options }) => options._name === 'nuxt-test-utils',
+    )!.options
+  }
+
+  function hasNuxtPage() {
+    return getVueWrapperPlugin().hasNuxtPage()
+  }
+})

--- a/examples/app-vitest-full/tests/resolved-files.spec.ts
+++ b/examples/app-vitest-full/tests/resolved-files.spec.ts
@@ -18,7 +18,7 @@ test('it should include nuxt spec files', { timeout: 30000 }, async () => {
   const nuxtSpecFiles = testFiles.filter(file => file.moduleId.endsWith('nuxt.spec.ts') || NUXT_PATH_RE.test(file.moduleId))
   const regularSpecFiles = testFiles.filter(file => file.moduleId.endsWith('.spec.ts') && !file.moduleId.endsWith('nuxt.spec.ts') && !NUXT_PATH_RE.test(file.moduleId))
 
-  expect(nuxtSpecFiles.length).toEqual(23)
+  expect(nuxtSpecFiles.length).toEqual(24)
   for (const file of nuxtSpecFiles) {
     expect(file.project.name).toEqual('nuxt')
   }

--- a/src/runtime/shared/nuxt.ts
+++ b/src/runtime/shared/nuxt.ts
@@ -1,3 +1,5 @@
+import { getVueWrapperPlugin } from './vue-wrapper-plugin'
+
 export async function setupNuxt() {
   const { useRouter } = await import('#app/composables/router')
   // @ts-expect-error alias to allow us to transform the entrypoint
@@ -10,6 +12,10 @@ export async function setupNuxt() {
       ? nuxtApp._route.sync()
       : nuxtApp.callHook('page:finish')
   }
-  useRouter().afterEach(() => sync())
+  const { hasNuxtPage } = getVueWrapperPlugin()
+  useRouter().afterEach(() => {
+    if (hasNuxtPage()) return
+    return sync()
+  })
   return sync()
 }

--- a/src/runtime/shared/vue-wrapper-plugin.ts
+++ b/src/runtime/shared/vue-wrapper-plugin.ts
@@ -1,0 +1,52 @@
+import { config } from '@vue/test-utils'
+import type { VueWrapper } from '@vue/test-utils'
+
+type Options = ReturnType<typeof createPluginOptions>
+
+const PLUGIN_NAME = 'nuxt-test-utils'
+
+export function getVueWrapperPlugin(): Options {
+  const installed = config.plugins.VueWrapper.installedPlugins
+    .find(({ options }) => options._name === PLUGIN_NAME)
+
+  if (installed) return installed.options
+
+  const options = createPluginOptions()
+
+  config.plugins.VueWrapper.install((instance, options) => {
+    options.addInstance(instance)
+    return {}
+  }, options)
+
+  return options
+}
+
+function createPluginOptions() {
+  const options = {
+    _name: PLUGIN_NAME,
+    _instances: [] as WeakRef<VueWrapper>[],
+    get instances() {
+      const instances: VueWrapper[] = []
+      options._instances = options._instances.filter((ref) => {
+        const instance = ref.deref()
+        if (!instance) return false
+        instances.push(instance)
+        return true
+      })
+      return instances
+    },
+    addInstance(instance: VueWrapper) {
+      if (options.instances.includes(instance)) return
+      options._instances.push(new WeakRef(instance))
+    },
+    hasNuxtPage() {
+      return options._hasComponent('NuxtPage')
+    },
+    _hasComponent(componentName: string) {
+      return options.instances.some(v =>
+        v.exists() && v.findComponent({ name: componentName }).exists(),
+      )
+    },
+  }
+  return options
+}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

skip emulation for components using NuxtPage, as it handles route syncing and the page:finish hook.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
