### PR TITLE
fix(config): do not override vitest root with nuxt rootDir

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -101,6 +101,9 @@ export async function getVitestConfigFromNuxt(
     })
   }
 
+  // do not override vitest root
+  delete options.viteConfig.root
+
   options.viteConfig.plugins = (options.viteConfig.plugins || []).filter(p => !p || !('name' in p) || !excludedPlugins.includes(p.name))
 
   const resolver = createResolver(import.meta.url)

--- a/test/fixtures/basic/test/basic.nuxt.spec.ts
+++ b/test/fixtures/basic/test/basic.nuxt.spec.ts
@@ -1,0 +1,3 @@
+import { it } from 'vitest'
+
+it('basic/nuxt', () => {})

--- a/test/fixtures/basic/test/basic.spec.ts
+++ b/test/fixtures/basic/test/basic.spec.ts
@@ -1,0 +1,3 @@
+import { it } from 'vitest'
+
+it('basic', () => {})

--- a/test/fixtures/basic/vitest.config.ts
+++ b/test/fixtures/basic/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineVitestConfig } from '@nuxt/test-utils/config'
+
+export default defineVitestConfig({})

--- a/test/fixtures/override/test/app/nuxt.config.ts
+++ b/test/fixtures/override/test/app/nuxt.config.ts
@@ -1,0 +1,2 @@
+export default defineNuxtConfig({
+})

--- a/test/fixtures/override/test/override.spec.ts
+++ b/test/fixtures/override/test/override.spec.ts
@@ -1,0 +1,3 @@
+import { it } from 'vitest'
+
+it('override', () => {})

--- a/test/fixtures/override/vitest.config.ts
+++ b/test/fixtures/override/vitest.config.ts
@@ -1,0 +1,52 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+import { defineVitestProject } from '@nuxt/test-utils/config'
+
+export default defineConfig({
+  test: {
+    projects: [
+      await defineVitestProject({
+        test: {
+          name: 'nuxt1',
+          environment: 'nuxt',
+          include: ['./test/**.spec.ts'],
+          environmentOptions: {
+            nuxt: {
+              overrides: {
+                rootDir: fileURLToPath(new URL('test/app/', import.meta.url)),
+              },
+            },
+          },
+        },
+      }),
+      await defineVitestProject({
+        extends: true,
+        test: {
+          name: 'nuxt2',
+          environment: 'nuxt',
+          include: ['./test/**.spec.ts'],
+          environmentOptions: {
+            nuxt: {
+              overrides: {
+                rootDir: fileURLToPath(new URL('test/app/', import.meta.url)),
+              },
+            },
+          },
+        },
+      }),
+      {
+        test: {
+          name: 'unit1',
+          include: ['./test/**.spec.ts'],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'unit2',
+          include: ['./test/**.spec.ts'],
+        },
+      },
+    ],
+  },
+})

--- a/test/fixtures/project/nuxt-test/project-nuxt.spec.ts
+++ b/test/fixtures/project/nuxt-test/project-nuxt.spec.ts
@@ -1,0 +1,3 @@
+import { it } from 'vitest'
+
+it('project/nuxt', () => {})

--- a/test/fixtures/project/unit-test/project-unit.spec.ts
+++ b/test/fixtures/project/unit-test/project-unit.spec.ts
@@ -1,0 +1,3 @@
+import { it } from 'vitest'
+
+it('project unit', () => {})

--- a/test/fixtures/project/vitest.config.ts
+++ b/test/fixtures/project/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config'
+import { defineVitestProject } from '@nuxt/test-utils/config'
+
+export default defineConfig({
+  test: {
+    projects: [
+      await defineVitestProject({
+        test: {
+          name: 'nuxt',
+          include: ['./nuxt-test/**.spec.ts'],
+        },
+      }),
+      {
+        test: {
+          name: 'unit',
+          include: ['./unit-test/**.spec.ts'],
+        },
+      },
+    ],
+  },
+})

--- a/test/unit/resolve-config.spec.ts
+++ b/test/unit/resolve-config.spec.ts
@@ -1,0 +1,136 @@
+import { join, relative } from 'pathe'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+import { createVitest } from 'vitest/node'
+import type { Vitest } from 'vitest/node'
+
+type VitestCliOptions = Parameters<typeof createVitest>[1]
+
+describe('resolve config', () => {
+  describe('basic', async () => {
+    const expected = {
+      node: [
+        'test/basic.spec.ts',
+      ],
+      nuxt: [
+        'test/basic.nuxt.spec.ts',
+      ],
+    } as const
+
+    it('all', async () => {
+      expect(await globTestSpecifications('../fixtures/basic')).toEqual(expected)
+    })
+
+    it('spcific root', async () => {
+      expect(await globTestSpecifications('./', {
+        root: '../fixtures/basic',
+      })).toEqual(expected)
+    })
+  })
+
+  describe('project', async () => {
+    const expected = {
+      nuxt: [
+        'nuxt-test/project-nuxt.spec.ts',
+      ],
+      unit: [
+        'unit-test/project-unit.spec.ts',
+      ],
+    } as const
+
+    it('all', async () => {
+      expect(await globTestSpecifications('../fixtures/project')).toEqual(expected)
+    })
+
+    it('only spcific project', async () => {
+      expect(await globTestSpecifications('../fixtures/project', {
+        project: 'nuxt',
+      })).toEqual({ nuxt: expected.nuxt })
+    })
+
+    it('spcific root', async () => {
+      expect(await globTestSpecifications('./', {
+        root: '../fixtures/project',
+      })).toEqual(expected)
+    })
+  })
+
+  describe('override', () => {
+    const expected = {
+      nuxt1: [
+        'test/override.spec.ts',
+      ],
+      nuxt2: [
+        'test/override.spec.ts',
+      ],
+      unit1: [
+        'test/override.spec.ts',
+      ],
+      unit2: [
+        'test/override.spec.ts',
+      ],
+    } as const
+
+    it('all', async () => {
+      expect(await globTestSpecifications('../fixtures/override')).toEqual(expected)
+    })
+
+    it('only spcific project', async () => {
+      expect(await globTestSpecifications('../fixtures/override', {
+        project: ['nuxt1', 'nuxt2'],
+      })).toEqual({
+        nuxt1: expected.nuxt1,
+        nuxt2: expected.nuxt2,
+      })
+    })
+
+    it('spcific root', async () => {
+      expect(await globTestSpecifications('./', {
+        root: '../fixtures/override',
+      })).toEqual(expected)
+    })
+  })
+})
+
+async function globTestSpecifications(path: string, cliOptions?: VitestCliOptions) {
+  const cwd = process.cwd()
+  let vitest: Vitest | undefined
+
+  try {
+    process.chdir(fileURLToPath(new URL(path, import.meta.url)))
+
+    vitest = await createVitest('test', {
+      ...cliOptions,
+      filesOnly: true,
+      run: false,
+      watch: false,
+      cache: false,
+    })
+
+    const files = await vitest.globTestSpecifications()
+    const result: Record<string, string[]> = {}
+    const projectDir = join(vitest.config.root, vitest.config.dir)
+
+    for (const file of files) {
+      const project = file.project.name
+      const filename = relative(projectDir, file.moduleId)
+      result[project] ??= []
+      result[project].push(filename)
+    }
+
+    for (const key of Object.keys(result)) {
+      result[key as keyof typeof result]?.sort()
+    }
+
+    return result
+  }
+  finally {
+    try {
+      await vitest?.close()
+    }
+    finally {
+      process.chdir(cwd)
+    }
+  }
+}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this addresses the issue pointed out in this comment
https://github.com/nuxt/ui/pull/5794#discussion_r2656012964

and added some unit tests for the config.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
