### PR TITLE
fix(module): use devtools:before hook instead of direct config check

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -63,13 +63,9 @@ export default defineNuxtModule<NuxtVitestOptions>({
 
     const vitestWrapper = createVitestWrapper(options, nuxt)
 
-    const isDevToolsEnabled = typeof nuxt.options.devtools === 'boolean'
-      ? nuxt.options.devtools
-      : nuxt.options.devtools.enabled
-
-    if (isDevToolsEnabled) {
+    nuxt.hook('devtools:before', async () => {
       await setupDevTools(vitestWrapper, nuxt)
-    }
+    })
 
     if (options.startOnBoot) {
       vitestWrapper.start()


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

previously checked via options, but that missed some cases.
switched to using the [devtools:before hook](https://github.com/nuxt/devtools/blob/4bbdfca940afa5c10bc03e22f2abd17f1ef18338/packages/devtools-kit/src/_types/hooks.ts#L7C1-L10C34) to fix this.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
