### PR TITLE
test: add cleanup to resolve-config tests

### DIFF
--- a/test/unit/resolve-config.spec.ts
+++ b/test/unit/resolve-config.spec.ts
@@ -1,5 +1,6 @@
-import { join, relative } from 'pathe'
+import { rm } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
+import { join, relative } from 'pathe'
 import { describe, expect, it } from 'vitest'
 
 import { createVitest } from 'vitest/node'
@@ -95,10 +96,12 @@ describe('resolve config', () => {
 
 async function globTestSpecifications(path: string, cliOptions?: VitestCliOptions) {
   const cwd = process.cwd()
+  const workdir = fileURLToPath(new URL(path, import.meta.url))
+
   let vitest: Vitest | undefined
 
   try {
-    process.chdir(fileURLToPath(new URL(path, import.meta.url)))
+    process.chdir(workdir)
 
     vitest = await createVitest('test', {
       ...cliOptions,
@@ -128,6 +131,7 @@ async function globTestSpecifications(path: string, cliOptions?: VitestCliOption
   finally {
     try {
       await vitest?.close()
+      await rm(join(workdir, '.nuxt'), { recursive: true, force: true })
     }
     finally {
       process.chdir(cwd)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I've updated the unit tests for resolve config to remove the .nuxt folder after each test. 
I noticed this was necessary because running knip raised a warning.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
