### PR TITLE
fix(runtime-utils): keep endpoints from registerEndpoint in setup file

### DIFF
--- a/examples/app-vitest-workspace/test/registerEndpoint.nuxt.spec.ts
+++ b/examples/app-vitest-workspace/test/registerEndpoint.nuxt.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { registerEndpoint } from '@nuxt/test-utils/runtime'
+
+registerEndpoint('/register/endpoint/in-test-file', () => 'test-file')
+
+describe('registerEndpoint', () => {
+  it('registerEndpoint in setup file', async () => {
+    expect(await $fetch<string>('/register/endpoint/in-setup-file')).toBe('setup-file')
+  })
+
+  it('registerEndpoint in test file', async () => {
+    expect(await $fetch<string>('/register/endpoint/in-test-file')).toBe('test-file')
+  })
+
+  it('registerEndpoint in test suite', async () => {
+    registerEndpoint('/register/endpoint/in-test-suite', () => 'test-suite')
+    expect(await $fetch<string>('/register/endpoint/in-test-suite')).toBe('test-suite')
+  })
+})

--- a/examples/app-vitest-workspace/test/setup/setup-nuxt.ts
+++ b/examples/app-vitest-workspace/test/setup/setup-nuxt.ts
@@ -1,0 +1,3 @@
+import { registerEndpoint } from '@nuxt/test-utils/runtime'
+
+registerEndpoint('/register/endpoint/in-setup-file', () => 'setup-file')

--- a/examples/app-vitest-workspace/vitest.config.ts
+++ b/examples/app-vitest-workspace/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
         test: {
           name: 'nuxt',
           include: ['**/*.nuxt.spec.ts'],
+          setupFiles: ['test/setup/setup-nuxt.ts'],
         },
       }),
       {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It seems that endpointRegistry is being reset when `vi.resetModules()` is executed in the setup entry.
reproduction of the issue: https://stackblitz.com/edit/github-rjcplztc-zucewawq?file=package.json

### Reproduction

https://stackblitz.com/edit/github-rjcplztc-trvjofb6?file=package.json

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
