### PR TITLE
feat(runtime-utils): pass original to mockNuxtImport factory

### DIFF
--- a/examples/app-vitest-full/tests/nuxt/mock-nuxt-composable-4.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/mock-nuxt-composable-4.spec.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+mockNuxtImport(useAutoImportedTarget, (original) => {
+  return () => `useAutoImportedTarget mocked(${original()})`
+})
+
+mockNuxtImport(useDefaultExport, (original) => {
+  return () => `useDefaultExport mocked(${original()})`
+})
+
+mockNuxtImport(useRuntimeConfig, (original) => {
+  return (...args) => {
+    const value = original(...args)
+    return {
+      ...value,
+      public: {
+        ...value.public,
+        API_ENTRYPOINT: 'http://api.example.com',
+      },
+    }
+  }
+})
+
+mockNuxtImport(useRouter, (original) => {
+  return () => {
+    const value = original()
+    return {
+      ...value,
+      replace: vi.fn(value.replace),
+    }
+  }
+})
+
+describe('mock with original composables', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.restoreAllMocks()
+  })
+
+  it('should mock composables from project', () => {
+    expect(useAutoImportedTarget()).toBe('useAutoImportedTarget mocked(the original)')
+  })
+
+  it('should mock composable with default export', () => {
+    expect(useDefaultExport()).toBe('useDefaultExport mocked(the original)')
+  })
+
+  it('should extend original composable return value', () => {
+    expect(useRuntimeConfig()).toMatchObject({
+      app: {
+        baseURL: '/',
+        buildAssetsDir: '/_nuxt/',
+        buildId: 'test',
+      },
+      nitro: {
+        envPrefix: 'NUXT_',
+      },
+      public: {
+        API_ENTRYPOINT: 'http://api.example.com',
+        hello: 'world',
+        testValue: 123,
+      },
+    })
+  })
+
+  it('should be able to partially mock the original', async () => {
+    const router = useRouter()
+    expect(router.currentRoute.value.path).toBe('/')
+
+    await router.replace('/test1')
+    expect(router.currentRoute.value.path).toBe('/test1')
+    expect(vi.mocked(router.replace)).toHaveBeenLastCalledWith('/test1')
+
+    vi.mocked(router.replace).mockImplementationOnce(() => Promise.resolve())
+    await router.replace('/test2')
+    expect(router.currentRoute.value.path).toBe('/test1')
+    expect(vi.mocked(router.replace)).toHaveBeenLastCalledWith('/test2')
+  })
+})

--- a/examples/app-vitest-full/tests/resolved-files.spec.ts
+++ b/examples/app-vitest-full/tests/resolved-files.spec.ts
@@ -18,7 +18,7 @@ test('it should include nuxt spec files', { timeout: 30000 }, async () => {
   const nuxtSpecFiles = testFiles.filter(file => file.moduleId.endsWith('nuxt.spec.ts') || NUXT_PATH_RE.test(file.moduleId))
   const regularSpecFiles = testFiles.filter(file => file.moduleId.endsWith('.spec.ts') && !file.moduleId.endsWith('nuxt.spec.ts') && !NUXT_PATH_RE.test(file.moduleId))
 
-  expect(nuxtSpecFiles.length).toEqual(24)
+  expect(nuxtSpecFiles.length).toEqual(25)
   for (const file of nuxtSpecFiles) {
     expect(file.project.name).toEqual('nuxt')
   }

--- a/src/runtime-utils/mock.ts
+++ b/src/runtime-utils/mock.ts
@@ -107,7 +107,7 @@ export function registerEndpoint(url: string, options: H3V1EventHandler | { hand
  */
 export function mockNuxtImport<T = unknown>(
   _target: string | T,
-  _factory: () => T | Promise<T>,
+  _factory: (original: T) => T | Promise<T>,
 ): void {
   throw new Error(
     'mockNuxtImport() is a macro and it did not get transpiled. This may be an internal bug of @nuxt/test-utils.',

--- a/test/unit/mock-transform.spec.ts
+++ b/test/unit/mock-transform.spec.ts
@@ -55,11 +55,13 @@ describe('mocking', () => {
         vi.mock("bob", async (importOriginal) => {
           const mocks = globalThis.__NUXT_VITEST_MOCKS
           if (!mocks["bob"]) {
-            mocks["bob"] = { ...await importOriginal("bob") }
+            const original = await importOriginal("bob")
+            mocks["bob"] = { ...original }
+            mocks["bob"].__NUXT_VITEST_MOCKS_ORIGINAL = { ...original }
           }
           mocks["bob"]["useSomeExport"] = await (() => {
                   return () => 'mocked'
-                })();
+                })(mocks["bob"].__NUXT_VITEST_MOCKS_ORIGINAL["useSomeExport"]);
           return mocks["bob"] 
         });
 
@@ -108,9 +110,11 @@ describe('mocking', () => {
         vi.mock("bob", async (importOriginal) => {
           const mocks = globalThis.__NUXT_VITEST_MOCKS
           if (!mocks["bob"]) {
-            mocks["bob"] = { ...await importOriginal("bob") }
+            const original = await importOriginal("bob")
+            mocks["bob"] = { ...original }
+            mocks["bob"].__NUXT_VITEST_MOCKS_ORIGINAL = { ...original }
           }
-          mocks["bob"]["useSomeExport"] = await (() => 'bob')();
+          mocks["bob"]["useSomeExport"] = await (() => 'bob')(mocks["bob"].__NUXT_VITEST_MOCKS_ORIGINAL["useSomeExport"]);
           return mocks["bob"] 
         });
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

An original argument was added to the `mockNuxtImport`'s factory function. this makes partial mocking easier

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
