### PR TITLE
fix(deps): move vitest-environment-nuxt to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,10 +94,10 @@
     "tinyexec": "^1.1.1",
     "ufo": "^1.6.3",
     "unplugin": "^3.0.0",
-    "vitest-environment-nuxt": "workspace:*",
     "vue": "^3.5.32"
   },
   "devDependencies": {
+    "vitest-environment-nuxt": "workspace:*",
     "@cucumber/cucumber": "12.7.0",
     "@jest/globals": "30.3.0",
     "@nuxt/eslint-config": "1.15.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,9 +112,6 @@ importers:
       unplugin:
         specifier: ^3.0.0
         version: 3.0.0
-      vitest-environment-nuxt:
-        specifier: workspace:*
-        version: link:stubs/vitest-environment-nuxt
       vue:
         specifier: ^3.5.32
         version: 3.5.32(typescript@6.0.2)
@@ -209,6 +206,9 @@ importers:
       vitest:
         specifier: 4.1.2
         version: 4.1.2(@types/node@24.12.2)(@vitest/browser-playwright@4.1.2)(@vitest/ui@4.1.2)(happy-dom@20.8.9)(jsdom@29.0.2)(vite@8.0.5(@emnapi/core@1.7.1)(@emnapi/runtime@1.7.1)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+      vitest-environment-nuxt:
+        specifier: workspace:*
+        version: link:stubs/vitest-environment-nuxt
       vue-router:
         specifier: 5.0.4
         version: 5.0.4(@vue/compiler-sfc@3.5.32)(vue@3.5.32(typescript@6.0.2))


### PR DESCRIPTION
### 🔗 Linked issue

attempt to fix #1653 

### 📚 Description

as described in the issue, installing dependencies fails because of an error:
` ERR_PNPM_WORKSPACE_PKG_NOT_FOUND  In : "vitest-environment-nuxt@workspace:*" is in the dependencies but no package named "vitest-environment-nuxt" is present in the workspace`

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
