### PR TITLE
fix(runtime-utils): insert `compilerOptions` conditionally

### DIFF
--- a/src/runtime-utils/utils/suspended.ts
+++ b/src/runtime-utils/utils/suspended.ts
@@ -215,6 +215,10 @@ function mergeComponentMountingGlobalOptions<C>(
   options: ComponentMountingOptions<C>['global'] = {},
   defaults: typeof options = {},
 ): typeof options {
+  const compilerOptions = {
+    ...defaults.config?.compilerOptions,
+    ...options.config?.compilerOptions,
+  }
   return {
     ...options,
     mixins: [...defaults.mixins || [], ...options.mixins || []],
@@ -231,10 +235,7 @@ function mergeComponentMountingGlobalOptions<C>(
     config: {
       ...defaults.config,
       ...options.config,
-      compilerOptions: {
-        ...defaults.config?.compilerOptions,
-        ...options.config?.compilerOptions,
-      },
+      ...(Object.keys(compilerOptions).length ? { compilerOptions } : undefined),
       globalProperties: {
         ...defaults.config?.globalProperties,
         ...options.config?.globalProperties,


### PR DESCRIPTION
Prevents warning for Vue builds without a runtime compiler

### 🔗 Linked issue

Resolves #1658

### 📚 Description

Fixes a Vue warning if the Vue build does not include the compiler by only setting compiler options if they are non-empty.


