### PR TITLE
chore: fix typo

### DIFF
--- a/src/vitest-wrapper/cli.ts
+++ b/src/vitest-wrapper/cli.ts
@@ -6,7 +6,7 @@ import {
   listenHostMessages as listenMessages,
 } from './interface'
 import type {
-  SendToCliMessage as RecieveMessage,
+  SendToCliMessage as ReceiveMessage,
   SendToHostMessage as SendMessage,
 } from './interface'
 
@@ -68,7 +68,7 @@ async function main() {
   const {
     apiPorts,
     watchMode,
-  } = await new Promise<RecieveMessage['start']>((resolve) => {
+  } = await new Promise<ReceiveMessage['start']>((resolve) => {
     listenMessages(({ type, payload }) => {
       if (type === 'start') resolve(payload)
     })

--- a/src/vitest-wrapper/host.ts
+++ b/src/vitest-wrapper/host.ts
@@ -9,13 +9,13 @@ import {
 } from './interface'
 import type {
   SendToCliMessage as SendMessage,
-  SendToHostMessage as RecieveMessage,
+  SendToHostMessage as ReceiveMessage,
 } from './interface'
 
 import { distDir } from '#dirs'
 
 type Handlers = {
-  [K in keyof RecieveMessage]: ((payload: RecieveMessage[K]) => unknown)[]
+  [K in keyof ReceiveMessage]: ((payload: ReceiveMessage[K]) => unknown)[]
 } & {
   exited: ((payload: { exitCode: number }) => unknown)[]
 }


### PR DESCRIPTION
The vitest worker IPC wrapper imports its inbound message type alias as `RecieveMessage` in both:

- `src/vitest-wrapper/cli.ts:9` — `SendToCliMessage as RecieveMessage`
- `src/vitest-wrapper/host.ts:12` — `SendToHostMessage as RecieveMessage`

…and uses the alias 4 times across the two files. The alias is private to those files (neither is re-exported from the package entry points), so the rename is invisible to consumers but removes a spelling mistake from the public source.

Verification on touched files:

- `pnpm exec vue-tsc --noEmit` — no new errors on `src/vitest-wrapper/*` (other repo-level type errors are pre-existing and unrelated)
- `pnpm exec eslint src/vitest-wrapper` — clean