### PR TITLE
fix(runtime-utils): lazily import root-component in mount + render helpers

### DIFF
--- a/examples/app-vitest-full/components/GlobalComponent.global.vue
+++ b/examples/app-vitest-full/components/GlobalComponent.global.vue
@@ -1,5 +1,9 @@
 <template>
   <div>
-    I am a global component
+    {{ message }}
   </div>
 </template>
+
+<script setup lang="ts">
+const { message } = useGlobalComponentMessage()
+</script>

--- a/examples/app-vitest-full/composables/useGlobalComponentMessage.ts
+++ b/examples/app-vitest-full/composables/useGlobalComponentMessage.ts
@@ -1,0 +1,5 @@
+export function useGlobalComponentMessage() {
+  return {
+    message: ' I am a global component ',
+  }
+}

--- a/examples/app-vitest-full/tests/nuxt/mock-nuxt-composable-2.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/mock-nuxt-composable-2.spec.ts
@@ -1,10 +1,26 @@
 import { expect, it } from 'vitest'
-import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { mockNuxtImport, mountSuspended, renderSuspended } from '@nuxt/test-utils/runtime'
+
+import GlobalComponent from '~/components/GlobalComponent.global.vue'
 
 mockNuxtImport('useHead', () => {
   return () => true
 })
 
+mockNuxtImport(useGlobalComponentMessage, () => () => ({
+  message: '(mock) I am a global component',
+}))
+
 it('should mock core nuxt composables', () => {
   expect(useHead({})).toMatchInlineSnapshot('true')
+})
+
+it('should mock composables used in app.vue components with mountSuspended', async () => {
+  const wrapper = await mountSuspended(GlobalComponent)
+  expect(wrapper.html()).toContain('(mock) I am a global component')
+})
+
+it('should mock composables used in app.vue components with renderSuspended', async () => {
+  const wrapper = await renderSuspended(GlobalComponent)
+  expect(wrapper.html()).toContain('(mock) I am a global component')
 })

--- a/src/runtime-utils/mount.ts
+++ b/src/runtime-utils/mount.ts
@@ -1,6 +1,5 @@
 import { mount as wrapperFn } from '@vue/test-utils'
 import type { VueWrapper } from '@vue/test-utils'
-import { cleanupAll, wrapperSuspended } from './utils/suspended'
 import type { WrapperSuspendedOptions, WrapperSuspendedResult } from './utils/suspended'
 
 type WrapperFn<C> = typeof wrapperFn<C>
@@ -37,6 +36,8 @@ export async function mountSuspended<T>(
   component: T,
   options: WrapperOptions<T> = {},
 ): Promise<WrapperResult<T>> {
+  const { cleanupAll, wrapperSuspended } = await import('./utils/suspended')
+
   const suspendedHelperName = 'MountSuspendedHelper'
   const clonedComponentName = 'MountSuspendedComponent'
 

--- a/src/runtime-utils/render.ts
+++ b/src/runtime-utils/render.ts
@@ -1,5 +1,4 @@
 import { h, nextTick } from 'vue'
-import { cleanupAll, wrapperSuspended } from './utils/suspended'
 import type { WrapperSuspendedOptions, WrapperSuspendedResult } from './utils/suspended'
 
 import type { render } from '@testing-library/vue'
@@ -42,6 +41,8 @@ export async function renderSuspended<T>(
   component: T,
   options: WrapperOptions<T> = {},
 ): Promise<WrapperResult<T>> {
+  const { cleanupAll, wrapperSuspended } = await import('./utils/suspended')
+
   const wrapperId = 'test-wrapper'
   const suspendedHelperName = 'RenderHelper'
   const clonedComponentName = 'RenderSuspendedComponent'


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

resolves #1664

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

since importing `root-component` also imports `app-component` and `error-component`,  changed it to import them only when using `mountSuspended` or `renderSuspended`.

### Reproduction

<img width="1272" height="1616" alt="image" src="https://github.com/user-attachments/assets/c056f670-e60a-47ad-9c2a-d46a9cde9fdd" />


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
