### PR TITLE
fix(module): exclude test files from Nuxt plugin registration

### DIFF
--- a/src/module/mock.ts
+++ b/src/module/mock.ts
@@ -5,6 +5,10 @@ import { createMockPlugin } from './plugins/mock'
 import type { MockPluginContext } from './plugins/mock'
 import { loadKit } from '../utils'
 
+function isTestPluginFile(src: string) {
+  return src.includes('/plugins/') && (src.includes('.spec.') || src.includes('.test.'))
+}
+
 /**
  * This module is a macro that transforms `mockNuxtImport()` to `vi.mock()`,
  * which make it possible to mock Nuxt imports.
@@ -43,6 +47,11 @@ export async function setupImportMocking(nuxt: Nuxt) {
       nuxt._ignore.add(`!${pattern}`)
     }
   }
+
+  // But do not register test files inside plugins/ as real Nuxt plugins
+  nuxt.hook('app:resolve', (app) => {
+    app.plugins = app.plugins.filter(plugin => !isTestPluginFile(plugin.src))
+  })
 
   addVitePlugin(createMockPlugin(ctx).vite())
 }

--- a/src/module/mock.ts
+++ b/src/module/mock.ts
@@ -6,7 +6,7 @@ import type { MockPluginContext } from './plugins/mock'
 import { loadKit } from '../utils'
 
 function isTestPluginFile(src: string) {
-  return src.includes('/plugins/') && (src.includes('.spec.') || src.includes('.test.'))
+  return (src.includes('.spec.') || src.includes('.test.'))
 }
 
 /**

--- a/test/fixtures/simple/plugin-spec/nuxt.config.ts
+++ b/test/fixtures/simple/plugin-spec/nuxt.config.ts
@@ -1,0 +1,1 @@
+export default defineNuxtConfig({})

--- a/test/fixtures/simple/plugin-spec/plugins/customFetch.nuxt.spec.ts
+++ b/test/fixtures/simple/plugin-spec/plugins/customFetch.nuxt.spec.ts
@@ -1,0 +1,15 @@
+import { it, expect } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+mockNuxtImport('useHead', () => {
+  return () => 'mocked-head'
+})
+
+it('plugin spec runs under nuxt env', () => {
+  expect(globalThis.window).toBeDefined()
+  expect(globalThis.window).toHaveProperty('__NUXT_VITEST_ENVIRONMENT__', true)
+})
+
+it('mockNuxtImport works inside plugins/ directory', () => {
+  expect(useHead({})).toBe('mocked-head')
+})

--- a/test/fixtures/simple/plugin-spec/vitest.config.ts
+++ b/test/fixtures/simple/plugin-spec/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineVitestConfig } from '@nuxt/test-utils/config'
+
+export default defineVitestConfig({
+  test: {
+    environment: 'nuxt',
+  },
+})

--- a/test/unit/resolve-config.spec.ts
+++ b/test/unit/resolve-config.spec.ts
@@ -82,6 +82,20 @@ describe('resolve config', () => {
     }, TEST_TIMEOUT)
   })
 
+  describe('simple/plugin-spec', async () => {
+    const fixtureDir = '../fixtures/simple/plugin-spec'
+
+    const expected = {
+      nuxt: [
+        'plugins/customFetch.nuxt.spec.ts',
+      ],
+    } as const
+
+    it('all', async () => {
+      expect(await globTestSpecifications(fixtureDir)).toEqual(expected)
+    }, TEST_TIMEOUT)
+  })
+
   describe('simple/env-other', () => {
     const fixtureDir = '../fixtures/simple/env-other'
 


### PR DESCRIPTION
### 🔗 Linked issue
Fixes: https://github.com/nuxt/test-utils/issues/1203
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
`@nuxt/test-utils` unignored `*.spec.*` / `*.test.*` files so test files could be transformed by Nuxt, but this also caused files under `plugins/` to be treated as Nuxt plugins. As a result, `plugins/*.spec.ts` could be evaluated through Nuxt's plugin pipeline before Vitest collected the suite, so the tests were not collected correctly.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
