### PR TITLE
feat(vitest-environment): support `@vitest-environment-options`

### DIFF
--- a/examples/app-vitest-full/tests/nuxt/vitest-environment-options-1.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/vitest-environment-options-1.spec.ts
@@ -1,0 +1,17 @@
+// @vitest-environment-options { "domEnvironment": "jsdom" }
+
+import { expect, it } from 'vitest'
+
+it('can override domEnvironment via @vitest-environment-options', () => {
+  expect(navigator.userAgent).toContain('jsdom')
+})
+
+it('can access url from default options', () => {
+  expect(location.origin).toBe('http://localhost:3000')
+})
+
+it('can access runtimeConfig from resolved options', () => {
+  expect(useRuntimeConfig().public).toMatchObject({
+    hello: 'world',
+  })
+})

--- a/examples/app-vitest-full/tests/nuxt/vitest-environment-options-2.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/vitest-environment-options-2.spec.ts
@@ -1,0 +1,35 @@
+// @vitest-environment-options { "url": "http://localhost:8000" }
+
+import { expect, it } from 'vitest'
+import { registerEndpoint } from '@nuxt/test-utils/runtime'
+
+registerEndpoint('/api/vitest-environment-options/1', () => 'ok1')
+registerEndpoint('http://localhost:8000/api/vitest-environment-options/2', () => 'ok2')
+
+it('can override url via @vitest-environment-options', () => {
+  expect(location.origin).toBe('http://localhost:8000')
+})
+
+it('can access runtimeConfig from resolved options', () => {
+  expect(useRuntimeConfig().public).toMatchObject({
+    hello: 'world',
+  })
+})
+
+it('can access domEnvironment from resolved options', () => {
+  if (process.env.VITEST_DOM_ENV === 'jsdom') {
+    expect(navigator.userAgent).toContain('jsdom')
+  }
+  else {
+    expect(navigator.userAgent).not.toContain('jsdom')
+  }
+})
+
+it('can mock api endpoints with registerEndpoint', async () => {
+  expect(await $fetch<string>('/api/vitest-environment-options/1')).toBe('ok1')
+  expect(await $fetch<string>('http://localhost:8000/api/vitest-environment-options/2')).toBe('ok2')
+
+  expect(await fetch('/api/vitest-environment-options/1').then(r => r.text())).toBe('ok1')
+  expect(await fetch('http://localhost:8000/api/vitest-environment-options/2').then(r => r.text())).toBe('ok2')
+  expect(await fetch(new URL('/api/vitest-environment-options/2', location.origin)).then(r => r.text())).toBe('ok2')
+})

--- a/examples/app-vitest-full/tests/resolved-files.spec.ts
+++ b/examples/app-vitest-full/tests/resolved-files.spec.ts
@@ -19,6 +19,6 @@ test('it should include nuxt spec files', { timeout: 30000 }, async ({ onTestFin
   const nuxtSpecFiles = testFiles.filter(file => file.project.name === 'nuxt')
   const regularSpecFiles = testFiles.filter(file => file.project.name === 'node')
 
-  expect(nuxtSpecFiles.length).toEqual(26)
+  expect(nuxtSpecFiles.length).toEqual(28)
   expect(regularSpecFiles.length).toEqual(2)
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -371,7 +371,8 @@ async function resolveConfig<T extends ViteUserConfig & { test?: VitestConfig } 
 export interface NuxtEnvironmentOptions {
   rootDir?: string
   /**
-   * The starting URL for your Nuxt window environment
+   * The starting URL for your Nuxt window environment.
+   * Can be overridden via `@vitest-environment-options`.
    * @default 'http://localhost:3000'
    */
   url?: string
@@ -392,6 +393,7 @@ export interface NuxtEnvironmentOptions {
    * The name of the DOM environment to use.
    *
    * It also needs to be installed as a dev dependency in your project.
+   * Can be overridden via `@vitest-environment-options`.
    * @default 'happy-dom'
    */
   domEnvironment?: 'happy-dom' | 'jsdom'

--- a/src/environments/vitest/index.ts
+++ b/src/environments/vitest/index.ts
@@ -5,7 +5,7 @@ import { joinURL } from 'ufo'
 import defu from 'defu'
 
 import { setupWindow } from '../../runtime/shared/environment'
-import type { NuxtBuiltinEnvironment } from './types'
+import type { SetupWindowNuxtEnvironmentOptions } from '../../runtime/shared/environment'
 import happyDom from './env/happy-dom'
 import jsdom from './env/jsdom'
 
@@ -17,32 +17,32 @@ const environmentMap = {
 export default <Environment>{
   name: 'nuxt',
   viteEnvironment: 'client',
-  async setup(global, environmentOptions) {
+  async setup(global, _environmentOptions) {
     const { populateGlobal } = await importVitestEnvironments()
 
+    const environmentOptions = mergeSetupWindowEnvironmentOptions(_environmentOptions)
     const url = joinURL(
-      environmentOptions.nuxt?.url ?? 'http://localhost:3000',
+      environmentOptions.nuxt.url ?? 'http://localhost:3000',
       environmentOptions.nuxtRuntimeConfig?.app?.baseURL || '/',
     )
 
-    const environmentName = environmentOptions.nuxt?.domEnvironment as NuxtBuiltinEnvironment
+    const environmentName = environmentOptions.nuxt.domEnvironment || 'happy-dom'
     const environment = environmentMap[environmentName] || environmentMap['happy-dom']
     const { window: win, teardown } = await environment(global, defu(environmentOptions, {
       happyDom: { url },
       jsdom: { url },
     }))
 
-    if (environmentOptions.nuxt?.mock?.intersectionObserver) {
+    if (environmentOptions.nuxt.mock?.intersectionObserver) {
       win.IntersectionObserver ||= IntersectionObserver
     }
 
-    if (environmentOptions.nuxt?.mock?.indexedDb) {
+    if (environmentOptions.nuxt.mock?.indexedDb) {
       // @ts-expect-error win.indexedDB is read-only
       win.indexedDB = indexedDB
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const teardownWindow = await setupWindow(win, environmentOptions as any)
+    const teardownWindow = await setupWindow(win, environmentOptions)
     const { keys, originals } = populateGlobal(global, win, {
       bindFunctions: true,
       additionalKeys: ['fetch', 'Request'],
@@ -65,6 +65,30 @@ export default <Environment>{
       },
     }
   },
+}
+
+// Manually merge with base config because `@vitest-environment-options` doesn't merge by default
+function mergeSetupWindowEnvironmentOptions(
+  environmentOptions: Record<string, unknown> = {},
+): SetupWindowNuxtEnvironmentOptions {
+  const {
+    nuxt: nuxtEnvironmentOptions = {},
+  } = environmentOptions as unknown as SetupWindowNuxtEnvironmentOptions
+
+  const serializedResolvedOptions = process.env.__NUXT_VITEST_ENVIRONMENT_RESOLVED_OPTIONS__
+  const baseEnvironmentOptions = serializedResolvedOptions
+    ? JSON.parse(serializedResolvedOptions)
+    : environmentOptions
+
+  return defu(
+    {
+      nuxt: {
+        url: nuxtEnvironmentOptions.url,
+        domEnvironment: nuxtEnvironmentOptions.domEnvironment,
+      },
+    },
+    baseEnvironmentOptions,
+  )
 }
 
 // This can be removed when dropping support for vitest 4.0.x (We can static import from 'vitest/runtime')

--- a/src/module/plugins/options.ts
+++ b/src/module/plugins/options.ts
@@ -5,6 +5,7 @@ const PLUGIN_NAME = 'nuxt:vitest:nuxt-environment-options'
 const STUB_ID = 'nuxt-vitest-environment-options'
 
 export function NuxtVitestEnvironmentOptionsPlugin(environmentOptions: EnvironmentOptions = {}): Plugin {
+  const serializedOptions = JSON.stringify(environmentOptions)
   return {
     name: PLUGIN_NAME,
     enforce: 'pre',
@@ -15,7 +16,14 @@ export function NuxtVitestEnvironmentOptionsPlugin(environmentOptions: Environme
     },
     load(id) {
       if (id.endsWith(STUB_ID)) {
-        return `export default ${JSON.stringify(environmentOptions || {})}`
+        return `export default ${serializedOptions}`
+      }
+    },
+    config() {
+      return {
+        define: {
+          'process.env.__NUXT_VITEST_ENVIRONMENT_RESOLVED_OPTIONS__': JSON.stringify(serializedOptions),
+        },
       }
     },
   }

--- a/src/runtime/shared/environment.ts
+++ b/src/runtime/shared/environment.ts
@@ -7,15 +7,22 @@ import type { NuxtEnvironmentOptions } from '../../config'
 import { createFetchForH3V1 } from './h3-v1'
 import { createFetchForH3V2 } from './h3-v2'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function setupWindow(win: NuxtWindow, environmentOptions: { nuxt: NuxtEnvironmentOptions, nuxtRuntimeConfig?: Record<string, any>, nuxtRouteRules?: Record<string, any> }) {
+export interface SetupWindowNuxtEnvironmentOptions {
+  nuxt: NuxtEnvironmentOptions
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  nuxtRuntimeConfig?: Record<string, any>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  nuxtRouteRules?: Record<string, any>
+}
+
+export async function setupWindow(win: NuxtWindow, environmentOptions: SetupWindowNuxtEnvironmentOptions) {
   win.__NUXT_VITEST_ENVIRONMENT__ = true
   win.__NUXT__ = {
     serverRendered: false,
     config: {
       public: {},
       app: { baseURL: '/' },
-      ...environmentOptions?.nuxtRuntimeConfig,
+      ...environmentOptions.nuxtRuntimeConfig,
     },
     data: {},
     state: {},
@@ -70,8 +77,8 @@ export async function setupWindow(win: NuxtWindow, environmentOptions: { nuxt: N
   )
   const matcher = exportMatcher(routeRulesMatcher)
   const manifestOutputPath = joinURL(
-    environmentOptions?.nuxtRuntimeConfig?.app?.baseURL || '/',
-    environmentOptions?.nuxtRuntimeConfig?.app?.buildAssetsDir || '_nuxt',
+    environmentOptions.nuxtRuntimeConfig?.app?.baseURL || '/',
+    environmentOptions.nuxtRuntimeConfig?.app?.buildAssetsDir || '_nuxt',
     'builds',
   )
   const manifestBaseRoutePath = joinURL('/_', manifestOutputPath)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

resolves #1541

### 📚 Description

Added support for `@vitest-environment-options`, initially limited to `url` and `domEnvironment` as they are safe to change per test file.

### Reproduction

Before:
https://stackblitz.com/edit/nuxt-test-utils-pull-1673-before?file=package.json

After:
https://stackblitz.com/edit/nuxt-test-utils-pull-1673-after?file=package.json

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
