### PR TITLE
fix(e2e): wait for HTTP readiness before resolving `startServer`

### DIFF
--- a/src/e2e/context.ts
+++ b/src/e2e/context.ts
@@ -14,6 +14,7 @@ export function createTestContext(options: Partial<TestOptions>): TestContext {
     configFile: 'nuxt.config',
     setupTimeout: isWindows ? 240_000 : 120_000,
     teardownTimeout: isWindows ? 60_000 : 30_000,
+    serverStartTimeout: isWindows ? 120_000 : 60_000,
     dev: !!JSON.parse(process.env.NUXT_TEST_DEV || 'false'),
     logLevel: 1,
     server: true,

--- a/src/e2e/server.ts
+++ b/src/e2e/server.ts
@@ -3,7 +3,6 @@ import { getRandomPort, waitForPort } from 'get-port-please'
 import type { $Fetch, FetchOptions } from 'ofetch'
 import { fetch as _fetch, createFetch } from 'ofetch'
 import { resolve } from 'pathe'
-import { isWindows } from 'std-env'
 import { joinURL } from 'ufo'
 import { useTestContext } from './context'
 
@@ -71,11 +70,10 @@ interface WaitForServerOptions {
 async function waitForServer({ host, port, dev }: WaitForServerOptions) {
   const ctx = useTestContext()
   const baseURL = ctx.nuxt?.options.app.baseURL ?? '/'
-  const timeout = ctx.options.serverStartTimeout ?? (isWindows ? 120_000 : 60_000)
-  const deadline = Date.now() + timeout
+  const deadline = Date.now() + ctx.options.serverStartTimeout
 
-  const portRetries = Math.max(1, Math.ceil(timeout / 1000))
-  await waitForPort(port, { retries: portRetries, host }).catch(() => {})
+  // Brief opportunistic port wait; the fetch loop below owns the real readiness budget.
+  await waitForPort(port, { retries: 8, host }).catch(() => {})
 
   let lastError: unknown
   while (Date.now() < deadline) {
@@ -84,7 +82,6 @@ async function waitForServer({ host, port, dev }: WaitForServerOptions) {
     }
     try {
       const res = await globalFetch(joinURL(ctx.url!, baseURL), { signal: AbortSignal.timeout(10_000) })
-      const body = await res.text()
       // any response means the server is accepting connections.
       // the dev server (`nuxi _dev`) is the one exception: it answers with
       // 503 or a 200 HTML placeholder containing `__NUXT_LOADING__` while the
@@ -92,7 +89,7 @@ async function waitForServer({ host, port, dev }: WaitForServerOptions) {
       if (dev && res.status === 503) {
         lastError = new Error(`Server responded with ${res.status} ${res.statusText}`)
       }
-      else if (dev && body.includes('__NUXT_LOADING__')) {
+      else if (dev && (await res.text()).includes('__NUXT_LOADING__')) {
         lastError = new Error('Dev server is still starting up')
       }
       else {
@@ -108,13 +105,30 @@ async function waitForServer({ host, port, dev }: WaitForServerOptions) {
   await stopServer()
   throw lastError instanceof Error
     ? lastError
-    : new Error(`Timeout (${timeout}ms) waiting for ${dev ? 'dev' : 'built'} server to become ready at ${ctx.url}`)
+    : new Error(`Timeout (${ctx.options.serverStartTimeout}ms) waiting for ${dev ? 'dev' : 'built'} server to become ready at ${ctx.url}`)
 }
 
 export async function stopServer() {
   const ctx = useTestContext()
-  if (ctx.serverProcess) {
-    ctx.serverProcess.kill()
+  const proc = ctx.serverProcess
+  if (!proc) {
+    return
+  }
+  ctx.serverProcess = undefined
+
+  // tinyexec resolves the process when it exits; swallow non-zero exits since
+  // we're killing it on purpose.
+  const exited = Promise.resolve(proc).then(() => {}, () => {})
+  const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
+
+  proc.kill()
+  // Wait for the child to actually exit, escalating to SIGKILL if it lingers.
+  // Without this, callers can race a still-running server and (on Windows
+  // especially) leave orphan processes holding the port.
+  await Promise.race([exited, sleep(5_000)])
+  if (proc.exitCode == null) {
+    proc.kill('SIGKILL')
+    await Promise.race([exited, sleep(5_000)])
   }
 }
 

--- a/src/e2e/server.ts
+++ b/src/e2e/server.ts
@@ -3,6 +3,7 @@ import { getRandomPort, waitForPort } from 'get-port-please'
 import type { $Fetch, FetchOptions } from 'ofetch'
 import { fetch as _fetch, createFetch } from 'ofetch'
 import { resolve } from 'pathe'
+import { isWindows } from 'std-env'
 import { joinURL } from 'ufo'
 import { useTestContext } from './context'
 
@@ -35,24 +36,6 @@ export async function startServer(options: StartServerOptions = {}) {
         },
       },
     })
-    await waitForPort(port, { retries: 32, host }).catch(() => {})
-    let lastError
-    for (let i = 0; i < 150; i++) {
-      await new Promise(resolve => setTimeout(resolve, 100))
-      try {
-        const res = await $fetch<string>(ctx.nuxt!.options.app.baseURL, {
-          responseType: 'text',
-        })
-        if (!res.includes('__NUXT_LOADING__')) {
-          return
-        }
-      }
-      catch (e) {
-        lastError = e
-      }
-    }
-    ctx.serverProcess.kill()
-    throw lastError || new Error('Timeout waiting for dev server!')
   }
   else {
     const outputDir = ctx.nuxt ? ctx.nuxt.options.nitro.output!.dir! : ctx.options.nuxtConfig.nitro!.output!.dir!
@@ -74,8 +57,52 @@ export async function startServer(options: StartServerOptions = {}) {
         },
       },
     )
-    await waitForPort(port, { retries: 20, host })
   }
+
+  await waitForServer({ host, port, dev: ctx.options.dev })
+}
+
+interface WaitForServerOptions {
+  host: string
+  port: number
+  dev: boolean
+}
+
+async function waitForServer({ host, port, dev }: WaitForServerOptions) {
+  const ctx = useTestContext()
+  const baseURL = ctx.nuxt?.options.app.baseURL ?? '/'
+  const timeout = ctx.options.serverStartTimeout ?? (isWindows ? 120_000 : 60_000)
+  const deadline = Date.now() + timeout
+
+  // Port-listening is a fast first signal but not authoritative: a bound
+  // socket does not always mean the request handler is live yet (esp. in
+  // built mode), so an HTTP probe follows below.
+  const portRetries = Math.max(1, Math.ceil(timeout / 1000))
+  await waitForPort(port, { retries: portRetries, host }).catch(() => {})
+
+  let lastError: unknown
+  while (Date.now() < deadline) {
+    if (ctx.serverProcess && (ctx.serverProcess.killed || ctx.serverProcess.exitCode != null)) {
+      throw new Error(`Server process exited before becoming ready (exit code: ${ctx.serverProcess.exitCode ?? 'unknown'})`)
+    }
+    try {
+      const res = await $fetch<string>(baseURL, { responseType: 'text' })
+      // `nuxi _dev` serves a placeholder containing `__NUXT_LOADING__` until
+      // the underlying dev server is ready; keep polling while we see it.
+      if (!res.includes('__NUXT_LOADING__')) {
+        return
+      }
+    }
+    catch (e) {
+      lastError = e
+    }
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+
+  await stopServer()
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`Timeout (${timeout}ms) waiting for ${dev ? 'dev' : 'built'} server to become ready at ${ctx.url}`)
 }
 
 export async function stopServer() {

--- a/src/e2e/server.ts
+++ b/src/e2e/server.ts
@@ -86,10 +86,19 @@ async function waitForServer({ host, port, dev }: WaitForServerOptions) {
       throw new Error(`Server process exited before becoming ready (exit code: ${ctx.serverProcess.exitCode ?? 'unknown'})`)
     }
     try {
-      const res = await $fetch<string>(baseURL, { responseType: 'text' })
-      // `nuxi _dev` serves a placeholder containing `__NUXT_LOADING__` until
-      // the underlying dev server is ready; keep polling while we see it.
-      if (!res.includes('__NUXT_LOADING__')) {
+      const res = await globalFetch(joinURL(ctx.url!, baseURL), { signal: AbortSignal.timeout(10_000) })
+      const body = await res.text()
+      // any response means the server is accepting connections.
+      // the dev server (`nuxi _dev`) is the one exception: it answers with
+      // 503 or a 200 HTML placeholder containing `__NUXT_LOADING__` while the
+      // underlying dev server is still starting up.
+      if (dev && res.status === 503) {
+        lastError = new Error(`Server responded with ${res.status} ${res.statusText}`)
+      }
+      else if (dev && body.includes('__NUXT_LOADING__')) {
+        lastError = new Error('Dev server is still starting up')
+      }
+      else {
         return
       }
     }

--- a/src/e2e/server.ts
+++ b/src/e2e/server.ts
@@ -74,9 +74,6 @@ async function waitForServer({ host, port, dev }: WaitForServerOptions) {
   const timeout = ctx.options.serverStartTimeout ?? (isWindows ? 120_000 : 60_000)
   const deadline = Date.now() + timeout
 
-  // Port-listening is a fast first signal but not authoritative: a bound
-  // socket does not always mean the request handler is live yet (esp. in
-  // built mode), so an HTTP probe follows below.
   const portRetries = Math.max(1, Math.ceil(timeout / 1000))
   await waitForPort(port, { retries: portRetries, host }).catch(() => {})
 

--- a/src/e2e/types.ts
+++ b/src/e2e/types.ts
@@ -36,6 +36,13 @@ export interface TestOptions {
    * @default 30000
    */
   teardownTimeout: number
+  /**
+   * The amount of time (in milliseconds) to wait for the dev or built server to become ready (i.e. respond successfully on the configured base URL) before failing.
+   *
+   * This is bounded by `setupTimeout`, so increasing this is only useful in combination with a sufficiently large `setupTimeout`.
+   * @default 120000 // on windows; otherwise 60000
+   */
+  serverStartTimeout: number
   waitFor: number
   /**
    * Under the hood, Nuxt test utils uses [`playwright`](https://playwright.dev) to carry out browser testing. If this option is set, a browser will be launched and can be controlled in the subsequent test suite.


### PR DESCRIPTION
this adds configurability for starting the server + avoids orphaned processes.

additionally, we don't just wait for port to become available, but perform a fetch request to make sure it's accepting connections