### PR TITLE
chore(e2e): add warning message for e2e in nuxt vitest setup

### DIFF
--- a/examples/app-vitest-workspace/app1/test/app.nuxt.spec.ts
+++ b/examples/app-vitest-workspace/app1/test/app.nuxt.spec.ts
@@ -4,4 +4,9 @@ describe('app', () => {
   it('useAppConfig', () => {
     expect(Object.keys(useAppConfig())).toEqual(['nuxt'])
   })
+
+  it('__NUXT_VITEST_RESOLVED__ is true', () => {
+    // @ts-expect-error injected global, not typed
+    expect(__NUXT_VITEST_RESOLVED__).toBe(true)
+  })
 })

--- a/examples/app-vitest-workspace/app1/test/index.unit.spec.ts
+++ b/examples/app-vitest-workspace/app1/test/index.unit.spec.ts
@@ -1,5 +1,12 @@
-import { expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
-it('unit test', () => {
-  expect(typeof window).toBe('undefined')
+describe('unit test', () => {
+  it('window is undefined', () => {
+    expect(typeof window).toBe('undefined')
+  })
+
+  it('__NUXT_VITEST_RESOLVED__ is undefined', () => {
+    // @ts-expect-error injected global, not typed
+    expect(typeof __NUXT_VITEST_RESOLVED__).toBe('undefined')
+  })
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -137,6 +137,7 @@ export async function getVitestConfigFromNuxt(
     {
       define: {
         'process.env.NODE_ENV': '"test"',
+        '__NUXT_VITEST_RESOLVED__': 'true',
       },
       resolve: {
         alias: {

--- a/src/e2e/setup/index.ts
+++ b/src/e2e/setup/index.ts
@@ -75,9 +75,17 @@ export function createTest(options: Partial<TestOptions>): TestHooks {
 }
 
 export async function setup(options: Partial<TestOptions> = {}) {
+  if (typeof __NUXT_VITEST_RESOLVED__ === 'boolean' && __NUXT_VITEST_RESOLVED__) {
+    console.warn(
+      'Do not use defineVitestConfig or defineVitestProject for end-to-end tests, as they only work with nuxt client-environment tests.\n'
+      + 'Please refer to the setup section: https://nuxt.com/docs/4.x/getting-started/testing#setup')
+  }
+
   const hooks = createTest(options)
 
   const setupFn = setupMaps[hooks.ctx.options.runner]
 
   await setupFn(hooks)
 }
+
+declare const __NUXT_VITEST_RESOLVED__: boolean | undefined


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

As noted in our discussion in #1690, using `defineVitestConfig` for E2E tests is confusing. This PR adds a warning to clarify that these are only for client-environment tests and to guide developers to the correct setup.

### Reproduction

https://stackblitz.com/edit/nuxt-test-utils-pull-1691?file=package.json

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
