### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,5 +177,5 @@
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,17 +3,6 @@ packages:
   - examples/module/playground
   - stubs/*
 
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - esbuild
-  - oxc-resolver
-  - unrs-resolver
-  - vue-demi
-
-onlyBuiltDependencies:
-  - better-sqlite3
-  - '@tailwindcss/oxide'
-
 overrides:
   '@cucumber/cucumber': 12.8.3
   '@nuxt/schema': 4.4.5
@@ -31,3 +20,12 @@ patchedDependencies:
 shellEmulator: true
 
 ignoreWorkspaceRootCheck: true
+
+allowBuilds:
+  "@parcel/watcher": false
+  "@tailwindcss/oxide": true
+  better-sqlite3: true
+  esbuild: false
+  oxc-resolver: false
+  unrs-resolver: false
+  vue-demi: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`