### PR TITLE
fix(config): patch `ssr.resolve.conditions` to remove `import`

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -215,14 +215,10 @@ export async function getVitestConfigFromNuxt(
               },
             }
           },
-        },
-        {
-          // https://github.com/nuxt/test-utils/issues/1635
-          name: 'nuxt:test-utils:patch-ssr-conditions',
-          enforce: 'post',
-          configEnvironment(name, config) {
-            if (name === 'ssr' && config.resolve?.conditions) {
-              config.resolve.conditions = config.resolve.conditions.filter(x => x !== 'import')
+          configResolved(config) {
+            // https://github.com/nuxt/test-utils/issues/1635
+            if (config.ssr.resolve?.conditions) {
+              config.ssr.resolve.conditions = config.ssr.resolve.conditions.filter(x => x !== 'import')
             }
           },
         },

--- a/src/config.ts
+++ b/src/config.ts
@@ -216,6 +216,16 @@ export async function getVitestConfigFromNuxt(
             }
           },
         },
+        {
+          // https://github.com/nuxt/test-utils/issues/1635
+          name: 'nuxt:test-utils:patch-ssr-conditions',
+          enforce: 'post',
+          configEnvironment(name, config) {
+            if (name === 'ssr' && config.resolve?.conditions) {
+              config.resolve.conditions = config.resolve.conditions.filter(x => x !== 'import')
+            }
+          },
+        },
       ],
     } satisfies ViteUserConfig,
     // resolved vite config


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

resolves #1635

### 📚 Description

This was an issue in `test-utils`.
`config.environments.ssr.resolve.conditions` seems to be applied to `config.ssr.resolve.conditions` for backward compatibility. If `'import'` is included in `config.ssr.resolve.conditions`, Vitest fails to resolve the `pg` module in test run.

### Reproduction

https://stackblitz.com/edit/nuxt-test-utils-pull-1732-after?file=package.json

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
