### PR TITLE
feat(e2e): silence server logs and allow customising log level

### DIFF
--- a/examples/app-vitest/server/api/log-test.get.ts
+++ b/examples/app-vitest/server/api/log-test.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(() => {
+  console.log('[test] server-log-marker')
+  return { ok: true }
+})

--- a/examples/app-vitest/test/server-logs.e2e.spec.ts
+++ b/examples/app-vitest/test/server-logs.e2e.spec.ts
@@ -1,0 +1,26 @@
+import { fileURLToPath } from 'node:url'
+import { $fetch, clearServerLogs, getServerLogs, setup } from '@nuxt/test-utils/e2e'
+import { describe, expect, it, vi } from 'vitest'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../', import.meta.url)),
+})
+
+describe('server log capture', () => {
+  it('captures console.log output from a server route', async () => {
+    clearServerLogs()
+    await $fetch('/api/log-test')
+    await vi.waitFor(() => {
+      expect(getServerLogs().some(line => line.includes('[test] server-log-marker'))).toBe(true)
+    })
+  })
+
+  it('clearServerLogs empties the buffer', async () => {
+    await $fetch('/api/log-test')
+    await vi.waitFor(() => {
+      expect(getServerLogs().length).toBeGreaterThan(0)
+    })
+    clearServerLogs()
+    expect(getServerLogs()).toHaveLength(0)
+  })
+})

--- a/src/e2e/context.ts
+++ b/src/e2e/context.ts
@@ -27,7 +27,12 @@ export function createTestContext(options: Partial<TestOptions>): TestContext {
     browserOptions: {
       type: 'chromium' as const,
     },
+    captureServerLogs: true,
   } satisfies Partial<TestOptions>)
+
+  if (process.env.NUXT_TEST_LOG_LEVEL) {
+    _options.logLevel = Number(process.env.NUXT_TEST_LOG_LEVEL)
+  }
 
   if (!_options.dev) {
     _options.env!.NODE_ENV ||= 'production'
@@ -52,6 +57,7 @@ export function createTestContext(options: Partial<TestOptions>): TestContext {
   return setTestContext({
     options: _options as TestOptions,
     url: withTrailingSlash(_options.host),
+    serverLogs: [],
   })
 }
 

--- a/src/e2e/server.ts
+++ b/src/e2e/server.ts
@@ -10,26 +10,36 @@ const globalFetch = globalThis.fetch || _fetch
 
 export interface StartServerOptions {
   env?: Record<string, unknown>
+  /**
+   * Overrides the consola log level for the server subprocess.
+   * Defaults to `TestOptions.logLevel` (which itself defaults to `1`).
+   */
+  logLevel?: number
 }
 
 export async function startServer(options: StartServerOptions = {}) {
   const ctx = useTestContext()
   await stopServer()
+  ctx.serverLogs = []
   const host = '127.0.0.1'
   const port = ctx.options.port || (await getRandomPort(host))
   ctx.url = `http://${host}:${port}/`
+  const capture = ctx.options.captureServerLogs !== false
+  const stdio = capture ? 'pipe' : 'inherit'
+  const logLevel = String(options.logLevel ?? ctx.options.logLevel)
   if (ctx.options.dev) {
     ctx.serverProcess = x('nuxi', ['_dev'], {
       throwOnError: true,
       nodeOptions: {
         cwd: ctx.nuxt!.options.rootDir,
-        stdio: 'inherit',
+        stdio,
         env: {
           ...process.env,
           _PORT: String(port), // Used by internal _dev command
           PORT: String(port),
           HOST: host,
           NODE_ENV: 'development',
+          CONSOLA_LEVEL: logLevel,
           ...ctx.options.env,
           ...options.env,
         },
@@ -49,18 +59,27 @@ export async function startServer(options: StartServerOptions = {}) {
       {
         throwOnError: true,
         nodeOptions: {
-          stdio: 'inherit',
+          stdio,
           env: {
             ...process.env,
             PORT: String(port),
             HOST: host,
             NODE_ENV: 'test',
+            CONSOLA_LEVEL: logLevel,
             ...ctx.options.env,
             ...options.env,
           },
         },
       },
     )
+  }
+
+  if (capture) {
+    ;(async () => {
+      for await (const line of ctx.serverProcess!) {
+        ctx.serverLogs.push(line)
+      }
+    })().catch(() => {})
   }
 
   await waitForServer({ host, port, dev: ctx.options.dev })
@@ -135,6 +154,23 @@ export async function stopServer() {
     proc.kill('SIGKILL')
     await Promise.race([exited, sleep(5_000)])
   }
+}
+
+/**
+ * Returns the lines captured from the server subprocess's stdout/stderr since
+ * the last `startServer()` call (or `clearServerLogs()`).
+ * Only populated when `captureServerLogs` is `true` (the default).
+ */
+export function getServerLogs(): string[] {
+  return useTestContext().serverLogs
+}
+
+/**
+ * Clears the captured server log lines. Useful between requests when you want
+ * to assert only on the logs produced by a specific operation.
+ */
+export function clearServerLogs(): void {
+  useTestContext().serverLogs = []
 }
 
 export function fetch(path: string, options?: RequestInit) {

--- a/src/e2e/types.ts
+++ b/src/e2e/types.ts
@@ -77,6 +77,14 @@ export interface TestOptions {
    */
   port?: number
   env?: StartServerOptions['env']
+  /**
+   * Whether to capture server process output instead of inheriting stdio.
+   * When `true` (default), server stdout/stderr is suppressed from the console
+   * and accessible via `getServerLogs()`. Set to `false` to restore the old
+   * inherit-stdio behaviour (useful when debugging a test locally).
+   * @default true
+   */
+  captureServerLogs?: boolean
 }
 
 export interface TestContext {
@@ -86,6 +94,11 @@ export interface TestContext {
   url?: string
   serverProcess?: ReturnType<typeof exec>
   mockFn?: (...args: unknown[]) => unknown
+  /**
+   * Lines emitted to the server subprocess's stdout/stderr, in order.
+   * Only populated when `options.captureServerLogs` is `true`.
+   */
+  serverLogs: string[]
   /**
    * Functions to run on the vitest `afterAll` hook.
    * Useful for removing anything created during the test.


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this silences logs printed in the console when running a server e2e test, but also gives a way for tests to access this logging data (which I think previously wasn't possible)

additionally, it's possible to set the `logLevel` (previously hard-coded at 1)