### PR TITLE
fix(config): inline config for useRuntimeConfig() composable

### DIFF
--- a/examples/app-vitest-full/tests/paths.spec.ts
+++ b/examples/app-vitest-full/tests/paths.spec.ts
@@ -1,0 +1,11 @@
+/** @vitest-environment happy-dom */
+import { describe, expect, it } from 'vitest'
+// @ts-expect-error virtual module
+import { baseURL, buildAssetsDir } from '#internal/nuxt/paths'
+
+describe('generated paths module', () => {
+  it('resolves outside the nuxt environment', () => {
+    expect(() => baseURL()).not.toThrow()
+    expect(() => buildAssetsDir()).not.toThrow()
+  })
+})

--- a/examples/app-vitest-full/tests/resolved-files.spec.ts
+++ b/examples/app-vitest-full/tests/resolved-files.spec.ts
@@ -20,5 +20,5 @@ test('it should include nuxt spec files', { timeout: 30000 }, async ({ onTestFin
   const regularSpecFiles = testFiles.filter(file => file.project.name === 'node')
 
   expect(nuxtSpecFiles.length).toEqual(26)
-  expect(regularSpecFiles.length).toEqual(2)
+  expect(regularSpecFiles.length).toEqual(3)
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -50,7 +50,7 @@ export default defineNuxtModule<NuxtVitestOptions>({
           const contents = await original(data)
           return contents
             .replace(/^import \{ useRuntimeConfig \} from ['"]nitropack\/runtime['"]\n?/m, '')
-            .replace(/const getAppConfig = \(\) => useRuntimeConfig\(\)\.app/, `const getAppConfig = () => (${inlineAppConfig})`)
+            .replace(/const getAppConfig = \(\) => useRuntimeConfig\(\)\.app/, () => `const getAppConfig = () => (${inlineAppConfig})`)
         }
       })
     }

--- a/src/module.ts
+++ b/src/module.ts
@@ -37,6 +37,24 @@ export default defineNuxtModule<NuxtVitestOptions>({
       await setupImportMocking(nuxt)
     }
 
+    // inline runtime config the way dev builds do
+    if (nuxt.options.test && !nuxt.options.dev) {
+      nuxt.hook('app:templates', (app) => {
+        const template = app.templates.find(t => t.filename === 'paths.mjs')
+        if (!template?.getContents) {
+          return
+        }
+        const original = template.getContents
+        const inlineAppConfig = JSON.stringify(nuxt.options.app)
+        template.getContents = async (data) => {
+          const contents = await original(data)
+          return contents
+            .replace(/^import \{ useRuntimeConfig \} from ['"]nitropack\/runtime['"]\n?/m, '')
+            .replace(/const getAppConfig = \(\) => useRuntimeConfig\(\)\.app/, `const getAppConfig = () => (${inlineAppConfig})`)
+        }
+      })
+    }
+
     const { addVitePlugin } = await loadKit(nuxt.options.rootDir)
 
     const resolver = createResolver(import.meta.url)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

spotted this in https://github.com/elk-zone/elk/pull/3681 - `useRuntimeConfig()` currently throws if we don't set `window` properties, but I think we can resolve by inlining the config directly in the template the way this works in dev mode