### PR TITLE
fix(e2e): use `taskkill` to kill processes on windows

### DIFF
--- a/src/e2e/server.ts
+++ b/src/e2e/server.ts
@@ -1,5 +1,6 @@
-import { x } from 'tinyexec'
+import { x, xSync } from 'tinyexec'
 import { getRandomPort, waitForPort } from 'get-port-please'
+import { isWindows } from 'std-env'
 import type { $Fetch, FetchOptions } from 'ofetch'
 import { fetch as _fetch, createFetch } from 'ofetch'
 import { resolve } from 'pathe'
@@ -132,6 +133,23 @@ async function waitForServer({ host, port, dev }: WaitForServerOptions) {
     : new Error(`Timeout (${ctx.options.serverStartTimeout}ms) waiting for ${dev ? 'dev' : 'built'} server to become ready at ${ctx.url}`)
 }
 
+/**
+ * On Windows there are no process groups, and tinyexec routes commands that
+ * resolve to a `.cmd` shim (such as `nuxi`) through `cmd.exe /d /s /c`.
+ * `taskkill /T /F` walks the tree and terminates the descendants too.
+ */
+function killProcessTree(pid: number) {
+  try {
+    xSync('taskkill', ['/pid', String(pid), '/T', '/F'], {
+      throwOnError: false,
+      nodeOptions: { stdio: 'ignore' },
+    })
+  }
+  catch {
+    // taskkill exits non-zero when the process is already gone
+  }
+}
+
 export async function stopServer() {
   const ctx = useTestContext()
   const proc = ctx.serverProcess
@@ -145,10 +163,17 @@ export async function stopServer() {
   const exited = Promise.resolve(proc).then(() => {}, () => {})
   const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
 
+  const pid = proc.pid
+  if (isWindows && pid !== undefined) {
+    killProcessTree(pid)
+    await Promise.race([exited, sleep(5_000)])
+    return
+  }
+
   proc.kill()
   // Wait for the child to actually exit, escalating to SIGKILL if it lingers.
-  // Without this, callers can race a still-running server and (on Windows
-  // especially) leave orphan processes holding the port.
+  // Without this, callers can race a still-running server and leave orphan
+  // processes holding the port.
   await Promise.race([exited, sleep(5_000)])
   if (proc.exitCode == null) {
     proc.kill('SIGKILL')

--- a/src/e2e/setup/index.ts
+++ b/src/e2e/setup/index.ts
@@ -15,6 +15,27 @@ export const setupMaps = {
   vitest: setupVitest,
 }
 
+function withTimeout<T>(label: string, ms: number, promise: Promise<T>): Promise<T | undefined> {
+  let timedOut = false
+  let timer: ReturnType<typeof setTimeout>
+  const timeout = new Promise<undefined>((resolve) => {
+    timer = setTimeout(() => {
+      timedOut = true
+      console.warn(`[@nuxt/test-utils] Timed out after ${ms}ms ${label} during teardown. Continuing; some processes or file handles may still be held.`)
+      resolve(undefined)
+    }, ms)
+  })
+  const guarded = promise.catch((error) => {
+    if (timedOut) {
+      console.warn(`[@nuxt/test-utils] Error ${label} during teardown:`, error)
+      return undefined
+    }
+    throw error
+  }).finally(() => clearTimeout(timer))
+
+  return Promise.race([guarded, timeout])
+}
+
 export function createTest(options: Partial<TestOptions>): TestHooks {
   const ctx = createTestContext(options)
 
@@ -27,19 +48,24 @@ export function createTest(options: Partial<TestOptions>): TestHooks {
   }
 
   const afterAll = async () => {
+    // Every step is bounded against a single shared budget so that a shutdown
+    // that never settles degrades to a warning instead of failing the run.
+    const deadline = Date.now() + ctx.options.teardownTimeout
+    const remaining = () => Math.max(1_000, deadline - Date.now())
+
     if (ctx.serverProcess) {
       setTestContext(ctx)
       await stopServer()
       setTestContext(undefined)
     }
     if (ctx.nuxt && ctx.nuxt.options.dev) {
-      await ctx.nuxt.close()
+      await withTimeout('closing the Nuxt instance', remaining(), ctx.nuxt.close())
     }
     if (ctx.browser) {
-      await ctx.browser.close()
+      await withTimeout('closing the browser', remaining(), ctx.browser.close())
     }
     // clear side effects
-    await Promise.all(!ctx.teardown ? [] : ctx.teardown.map(fn => fn()))
+    await withTimeout('running teardown hooks', remaining(), Promise.all(!ctx.teardown ? [] : ctx.teardown.map(fn => fn())))
   }
 
   const beforeAll = async () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this fixes a couple of issues when tearing down a fixture on windows:

1. properly kill the whole task tree 

2. timeout the teardown so it doesn't fail the test suite