### PR TITLE
chore: replace `latest` ranges with caret ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@types/bun": "1.3.14",
     "@types/estree": "1.0.9",
     "@types/jsdom": "28.0.3",
-    "@types/node": "latest",
+    "@types/node": "^24.13.3",
     "@types/semver": "7.8.0",
     "@vitest/browser-playwright": "4.1.10",
     "@vue/test-utils": "2.4.11",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

`latest` is a curse and can easily drift, or change wildly on lockfile regeneration