### PR TITLE
fix(module): handle string presets in auto-imports

### DIFF
--- a/src/module/mock.ts
+++ b/src/module/mock.ts
@@ -34,7 +34,7 @@ export async function setupImportMocking(nuxt: Nuxt) {
 
   nuxt.hook('imports:sources', (presets) => {
     // because the native setInterval cannot be mocked
-    const idx = presets.findIndex(p => 'imports' in p && p.imports?.includes('setInterval'))
+    const idx = presets.findIndex(p => typeof p === 'object' && 'imports' in p && p.imports?.includes('setInterval'))
     if (idx !== -1) {
       presets.splice(idx, 1)
     }


### PR DESCRIPTION
### 📚 Description
When using string shorthand presets (e.g., 'date-fns') in `imports.presets`, the @nuxt/test-utils "mock" module throws a TypeError: `Cannot use 'in' operator to search for 'from' in date-fns`.

This occurs because the `imports:sources` hook assumes all sources are objects when searching for router imports. This commit adds a type guard (`typeof s === 'object'`) to safely ignore string presets.

### 🔗 Linked issue
Relates to [https://github.com/nuxt/nuxt/discussions/34988](https://github.com/nuxt/nuxt/discussions/34988)
And [https://github.com/nuxt/nuxt/pull/35013](https://github.com/nuxt/nuxt/pull/35013)