### PR TITLE
fix(runtime-utils): `mockNuxtImport` sourcemap mapped position

### DIFF
--- a/src/module/plugins/mock.ts
+++ b/src/module/plugins/mock.ts
@@ -250,7 +250,7 @@ export const createMockPlugin = (ctx: MockPluginContext) => createUnplugin(() =>
 
         return {
           code: s.toString(),
-          map: s.generateMap(),
+          map: s.generateMap({ hires: true }),
         }
       },
       // Place Vitest's mock plugin after all Nuxt plugins

--- a/test/unit/mock-transform.spec.ts
+++ b/test/unit/mock-transform.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest'
+import Module from 'node:module'
 import { rollup } from 'rollup'
 import type { InputPluginOption } from 'rollup'
 import { createMockPlugin } from '../../src/module/plugins/mock'
@@ -7,7 +8,7 @@ import type { MockPluginContext } from '../../src/module/plugins/mock'
 describe('mocking', () => {
   const pluginContext: MockPluginContext = { imports: [], components: [] }
   const plugin = createMockPlugin(pluginContext)
-  const getResult = (code: string) => new Promise<string>((resolve) => {
+  const getTransformResult = (code: string) => new Promise<{ code: string, sourcemap: Module.SourceMap }>((resolve, reject) => {
     const input = '/some/file.ts'
     rollup({
       input,
@@ -22,16 +23,22 @@ describe('mocking', () => {
           name: 'resolve',
           transform: {
             order: 'post',
-            handler: (code) => {
-              resolve(code)
+            handler(code, _) {
+              const sourcemap = this.getCombinedSourcemap()
+              resolve({
+                code,
+                sourcemap: new Module.SourceMap(sourcemap as unknown as Module.SourceMapPayload),
+              })
               // suppress any errors from rollup itself
               return 'export default 42'
             },
           },
         },
       ],
-    })
+    }).catch(reject)
   })
+
+  const getResult = (code: string) => getTransformResult(code).then(r => r.code)
 
   beforeEach(() => {
     pluginContext.components = []
@@ -90,14 +97,16 @@ describe('mocking', () => {
         name: 'useSomeExport',
         from: 'bob',
       }]
-      const code = await getResult(`
+      const source = `
         import { expect, vi, it } from 'vitest'
         mockNuxtImport('useSomeExport', () => 'bob')
         
         it('test', () => {
           const a = vi.fn()
+          expect(1).toBe(1)
         })
-      `)
+      `
+      const { code, sourcemap } = await getTransformResult(source)
       expect(code).toMatchInlineSnapshot(`
         "
                 import { expect, vi, it } from 'vitest'
@@ -121,11 +130,22 @@ describe('mocking', () => {
                 
                 it('test', () => {
                   const a = vi.fn()
+                  expect(1).toBe(1)
                 })
               
          import "bob";"
       `)
       expect(code).not.toContain('import {vi} from "vitest";')
+
+      expect(code.split('\n')[22]?.substring(10)).toBe('expect(1).toBe(1)')
+      expect(source.split('\n')[6]?.substring(10)).toBe('expect(1).toBe(1)')
+      expect(sourcemap.findEntry(22, 10)).toMatchObject({
+        generatedLine: 22,
+        generatedColumn: 10,
+        originalLine: 6,
+        originalColumn: 10,
+        originalSource: '/some/file.ts',
+      })
     })
   })
 
@@ -141,10 +161,17 @@ describe('mocking', () => {
         shortPath: 'thing.vue',
         filePath: '/test/thing.vue',
       }]
-      expect(await getResult(`
+      const source = `
         import { mockComponent } from '@nuxt/test-utils/runtime'
         mockComponent('MyComponent', () => import('./MockComponent.vue'))
-      `)).toMatchInlineSnapshot(`
+
+        it('test', () => {
+          const a = vi.fn()
+          expect(1).toBe(1)
+        })
+      `
+      const { code, sourcemap } = await getTransformResult(source)
+      expect(code).toMatchInlineSnapshot(`
         "import {vi} from "vitest";
 
         vi.hoisted(() => { 
@@ -161,8 +188,23 @@ describe('mocking', () => {
 
                 import { mockComponent } from '@nuxt/test-utils/runtime'
                 
+
+                it('test', () => {
+                  const a = vi.fn()
+                  expect(1).toBe(1)
+                })
               "
       `)
+
+      expect(code.split('\n')[19]?.substring(10)).toBe('expect(1).toBe(1)')
+      expect(source.split('\n')[6]?.substring(10)).toBe('expect(1).toBe(1)')
+      expect(sourcemap.findEntry(19, 10)).toMatchObject({
+        generatedLine: 19,
+        generatedColumn: 10,
+        originalLine: 6,
+        originalColumn: 10,
+        originalSource: '/some/file.ts',
+      })
     })
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

resolves #1786

### 📚 Description

reproduction:
https://stackblitz.com/edit/nuxt-test-utils-issues-1786?file=package.json

```text
AssertionError: expected 1 to be 999 // Object.is equality

- Expected
+ Received

- 999
+ 1

 ❯ test/nuxt/repro.test.ts:10:15
      8| describe('non-working example', () => {
      9|   it('source line numbers are incorrect when mockNuxtImport is called', () => {
     10|     expect(1).toBe(999)
       |               ^
     11|   })
     12| })
```

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
