### PR TITLE
test: re-enable bun browser e2e on windows

### DIFF
--- a/examples/app-bun/test/browser.e2e.spec.ts
+++ b/examples/app-bun/test/browser.e2e.spec.ts
@@ -3,17 +3,12 @@ import { describe, it, expect } from 'bun:test'
 import { createPage, setup } from '@nuxt/test-utils/e2e'
 import { isWindows } from 'std-env'
 
-// Skip tests on windows because playwright cannot be launched with bun.
-// See: https://github.com/oven-sh/bun/issues/15679
+await setup({
+  rootDir: fileURLToPath(new URL('../', import.meta.url)),
+  browser: true,
+})
 
-if (!isWindows) {
-  await setup({
-    rootDir: fileURLToPath(new URL('../', import.meta.url)),
-    browser: true,
-  })
-}
-
-describe.skipIf(isWindows)('browser', () => {
+describe('browser', () => {
   it('runs a test', async () => {
     const page = await createPage('/')
     const text = await page.getByRole('heading', { name: 'Get started' }).textContent()


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Re-enabled bun browser e2e on windows, as the underlying playwright issue was fixed in bun v1.4

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
