### PR TITLE
test: make sure tests are collected at runtime, not statically

### DIFF
--- a/test/unit/resolve-config.spec.ts
+++ b/test/unit/resolve-config.spec.ts
@@ -319,7 +319,7 @@ async function collectTestSpecifications(path: string, cliOptions?: VitestCliOpt
   return runWithVitest(path, cliOptions ?? {}, async (vitest) => {
     const result: Record<string, string[]> = {}
 
-    const collects = await vitest.collect()
+    const collects = await vitest.collect([], { staticParse: false })
     for (const testModule of collects.testModules) {
       const project = testModule.project.name || testModule.project.config.environment
       const viteEnvName = testModule.viteEnvironment?.name || ''


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

In the latest Vitest 5 rc we changed the default for `vitest.collect` to statically collect tests instead of running them at runtime. The option exists since 4.1, this just makes sure the behaviour in the Nuxt test is consistent between the majors.

See https://github.com/vitest-dev/vitest-ecosystem-ci/actions/runs/33385971363/job/99468551633

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
