### PR TITLE
feat(runtime-utils): add route middleware testing utility

### DIFF
--- a/examples/app-vitest-full/tests/nuxt/middleware.spec.ts
+++ b/examples/app-vitest-full/tests/nuxt/middleware.spec.ts
@@ -1,5 +1,8 @@
 import { it, describe, expect, beforeEach, vi } from 'vitest'
-import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { mockNuxtImport, runRouteMiddleware } from '@nuxt/test-utils/runtime'
+import type { RouteMiddleware } from 'nuxt/app'
+
+import counterMiddleware from '~/middleware/01.global-counter.global'
 
 const {
   incrementMock,
@@ -54,5 +57,63 @@ describe('middleware', () => {
     expect(route.path).toBe('/')
     expect(incrementMock).toHaveBeenCalledOnce()
     expect(navigateToMock).toHaveBeenLastCalledWith('/count/just/1000')
+  })
+
+  it('can run a route middleware without navigating', async () => {
+    const route = useRoute()
+    const currentPath = route.fullPath
+
+    incrementMock.mockImplementation(() => 1000)
+
+    const result = await runRouteMiddleware(counterMiddleware, {
+      to: '/',
+      from: route,
+    })
+
+    expect(result).toBe('/count/just/1000')
+    expect(route.fullPath).toBe(currentPath)
+    expect(incrementMock).toHaveBeenCalledOnce()
+  })
+
+  it('normalizes the to and from routes', async () => {
+    let routes: Parameters<RouteMiddleware> | undefined
+    const middleware = defineNuxtRouteMiddleware((...args) => {
+      routes = args
+    })
+
+    await runRouteMiddleware(middleware, {
+      to: '/other/example?tab=settings',
+      from: '/about',
+    })
+
+    expect(routes?.[0]).toMatchObject({
+      path: '/other/example',
+      fullPath: '/other/example?tab=settings',
+      params: { slug: 'example' },
+      query: { tab: 'settings' },
+    })
+    expect(routes?.[1]).toMatchObject({
+      path: '/about',
+      fullPath: '/about',
+    })
+  })
+
+  it('supports aborting navigation', async () => {
+    const middleware = defineNuxtRouteMiddleware(() => abortNavigation())
+
+    await expect(runRouteMiddleware(middleware, { to: '/about' })).resolves.toBe(false)
+  })
+
+  it('restores the middleware context when middleware throws', async () => {
+    const nuxtApp = useNuxtApp()
+    const middleware = defineNuxtRouteMiddleware(() => {
+      return abortNavigation({ statusCode: 403, statusMessage: 'Forbidden' })
+    })
+
+    await expect(runRouteMiddleware(middleware, { to: '/about' })).rejects.toMatchObject({
+      statusCode: 403,
+      statusMessage: 'Forbidden',
+    })
+    expect(nuxtApp._processingMiddleware).toBeUndefined()
   })
 })

--- a/src/runtime-utils/index.ts
+++ b/src/runtime-utils/index.ts
@@ -1,3 +1,5 @@
 export { registerEndpoint, mockNuxtImport, mockComponent } from './mock.ts'
 export { mountSuspended } from './mount.ts'
 export { renderSuspended } from './render.ts'
+export { runRouteMiddleware } from './middleware.ts'
+export type { RouteMiddlewareLocation, RunRouteMiddlewareOptions } from './middleware.ts'

--- a/src/runtime-utils/middleware.ts
+++ b/src/runtime-utils/middleware.ts
@@ -1,0 +1,87 @@
+import type {
+  NavigationGuard,
+  RouteLocationNormalized,
+  RouteLocationNormalizedLoaded,
+  RouteLocationRaw,
+  Router,
+} from 'vue-router'
+
+import { useNuxtApp, useRouter } from '#imports'
+
+interface RouteMiddlewareLike {
+  (to: RouteLocationNormalized, from: RouteLocationNormalized): ReturnType<NavigationGuard>
+}
+
+export type RouteMiddlewareLocation = RouteLocationRaw | RouteLocationNormalized
+
+export interface RunRouteMiddlewareOptions {
+  /** The route being navigated to. */
+  to: RouteMiddlewareLocation
+  /**
+   * The route being navigated from.
+   * @default The router's current route.
+   */
+  from?: RouteMiddlewareLocation
+}
+
+function isNormalizedRoute(location: RouteMiddlewareLocation): location is RouteLocationNormalized {
+  return typeof location === 'object' && 'matched' in location
+}
+
+function resolveRoute(
+  router: Router,
+  location: RouteMiddlewareLocation,
+  currentLocation?: RouteLocationNormalized,
+): RouteLocationNormalized {
+  if (isNormalizedRoute(location)) {
+    return location
+  }
+
+  // Vue Router's resolved route type allows a nullable name, while Nuxt's middleware type does not.
+  return router.resolve(location, currentLocation as RouteLocationNormalizedLoaded | undefined) as RouteLocationNormalized
+}
+
+/**
+ * Returns the middleware result as-is without performing an actual route navigation.
+ *
+ * @param middleware The route middleware to run.
+ * @param options The routes to pass to the middleware.
+ */
+export async function runRouteMiddleware<T extends RouteMiddlewareLike>(
+  middleware: T,
+  options: RunRouteMiddlewareOptions,
+): Promise<Awaited<ReturnType<T>>> {
+  const nuxtApp = useNuxtApp()
+  const router = useRouter()
+  const from = resolveRoute(router, options.from ?? router.currentRoute.value)
+  const to = resolveRoute(router, options.to, from)
+
+  const previousProcessingMiddleware = nuxtApp._processingMiddleware
+  const previousMiddlewareTo = nuxtApp._middlewareTo
+
+  nuxtApp._processingMiddleware = (middleware as RouteMiddlewareLike & { _path?: string })._path || true
+  if (import.meta.server) {
+    nuxtApp._middlewareTo = to
+  }
+
+  try {
+    return await nuxtApp.runWithContext(() => middleware(to, from)) as Awaited<ReturnType<T>>
+  }
+  finally {
+    if (previousProcessingMiddleware === undefined) {
+      delete nuxtApp._processingMiddleware
+    }
+    else {
+      nuxtApp._processingMiddleware = previousProcessingMiddleware
+    }
+
+    if (import.meta.server) {
+      if (previousMiddlewareTo === undefined) {
+        delete nuxtApp._middlewareTo
+      }
+      else {
+        nuxtApp._middlewareTo = previousMiddlewareTo
+      }
+    }
+  }
+}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
`@nuxt/test-utils` currently does not provide a utility for testing Nuxt route middleware in isolation.

To test middleware that uses Nuxt APIs such as `navigateTo()`, users currently need to either:

- perform an actual navigation in a Nuxt environment, or
- create their own utility that reproduces the Nuxt context required to execute middleware.

Using an actual navigation may also run unrelated global middleware and change the current route. This makes it difficult to test the behavior of a specific middleware in isolation.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
