### PR TITLE
fix(config): default nuxt test pattern to nested for simple non-nuxt setup

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -359,7 +359,7 @@ export function defineVitestConfig(config: ViteUserConfig & { test?: VitestConfi
 
       nuxtProject.test.include = [
         '**/*.nuxt.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
-        '{test,tests}/nuxt/**.*',
+        '{test,tests}/nuxt/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       ]
 
       const defaultProject = merge({
@@ -374,8 +374,7 @@ export function defineVitestConfig(config: ViteUserConfig & { test?: VitestConfi
             '**/cypress/**',
             '**/.{idea,git,cache,output,temp}/**',
             '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*',
-            './**/*.nuxt.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
-            './{test,tests}/nuxt/**.*',
+            ...nuxtProject.test.include,
           ],
         },
       }, resolvedConfig)

--- a/test/fixtures/simple/env-none-include/test/nuxt/nest/test1.test.ts
+++ b/test/fixtures/simple/env-none-include/test/nuxt/nest/test1.test.ts
@@ -1,0 +1,6 @@
+import { it, expect } from 'vitest'
+
+it('nuxt/nest', () => {
+  expect(globalThis.window).toBeDefined()
+  expect(globalThis.window).toHaveProperty('__NUXT_VITEST_ENVIRONMENT__', true)
+})

--- a/test/fixtures/simple/env-none-include/test/nuxt/test.spec.ts
+++ b/test/fixtures/simple/env-none-include/test/nuxt/test.spec.ts
@@ -1,0 +1,6 @@
+import { it, expect } from 'vitest'
+
+it('nuxt/', () => {
+  expect(globalThis.window).toBeDefined()
+  expect(globalThis.window).toHaveProperty('__NUXT_VITEST_ENVIRONMENT__', true)
+})

--- a/test/fixtures/simple/env-none/test/nuxt/nest/test1.test.ts
+++ b/test/fixtures/simple/env-none/test/nuxt/nest/test1.test.ts
@@ -1,0 +1,6 @@
+import { it, expect } from 'vitest'
+
+it('nuxt/nest', () => {
+  expect(globalThis.window).toBeDefined()
+  expect(globalThis.window).toHaveProperty('__NUXT_VITEST_ENVIRONMENT__', true)
+})

--- a/test/fixtures/simple/env-none/test/nuxt/test.spec.ts
+++ b/test/fixtures/simple/env-none/test/nuxt/test.spec.ts
@@ -1,0 +1,6 @@
+import { it, expect } from 'vitest'
+
+it('nuxt/', () => {
+  expect(globalThis.window).toBeDefined()
+  expect(globalThis.window).toHaveProperty('__NUXT_VITEST_ENVIRONMENT__', true)
+})

--- a/test/fixtures/simple/env-other/test/nuxt/nest/test1.nuxt.spec.ts
+++ b/test/fixtures/simple/env-other/test/nuxt/nest/test1.nuxt.spec.ts
@@ -1,0 +1,6 @@
+import { it, expect } from 'vitest'
+
+it('nuxt/nest.nuxt', () => {
+  expect(globalThis.window).toBeDefined()
+  expect(globalThis.window).toHaveProperty('__NUXT_VITEST_ENVIRONMENT__', true)
+})

--- a/test/fixtures/simple/env-other/test/nuxt/nest/test1.test.ts
+++ b/test/fixtures/simple/env-other/test/nuxt/nest/test1.test.ts
@@ -1,0 +1,6 @@
+import { it, expect } from 'vitest'
+
+it('nuxt/nest', () => {
+  expect(globalThis.window).toBeDefined()
+  expect(globalThis.window).toHaveProperty('__NUXT_VITEST_ENVIRONMENT__', true)
+})

--- a/test/fixtures/simple/env-other/test/nuxt/test.spec.ts
+++ b/test/fixtures/simple/env-other/test/nuxt/test.spec.ts
@@ -1,0 +1,6 @@
+import { it, expect } from 'vitest'
+
+it('nuxt/', () => {
+  expect(globalThis.window).toBeDefined()
+  expect(globalThis.window).toHaveProperty('__NUXT_VITEST_ENVIRONMENT__', true)
+})

--- a/test/unit/resolve-config.spec.ts
+++ b/test/unit/resolve-config.spec.ts
@@ -20,6 +20,8 @@ describe('resolve config', () => {
         'test/test1.spec.ts',
       ],
       nuxt: [
+        'test/nuxt/nest/test1.test.ts',
+        'test/nuxt/test.spec.ts',
         'test/test1.nuxt.spec.ts',
       ],
     } as const
@@ -43,6 +45,8 @@ describe('resolve config', () => {
         'test/test1.spec.ts',
       ],
       nuxt: [
+        'test/nuxt/nest/test1.test.ts',
+        'test/nuxt/test.spec.ts',
         'test/test1.nuxt.spec.ts',
       ],
     } as const
@@ -106,6 +110,9 @@ describe('resolve config', () => {
 
     const expected = {
       'nuxt:client': [
+        'test/nuxt/nest/test1.nuxt.spec.ts',
+        'test/nuxt/nest/test1.test.ts',
+        'test/nuxt/test.spec.ts',
         'test/test1.nuxt.spec.ts',
       ],
       'node:ssr': [


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
resolves #1800

### 📚 Description

Updated the nuxt test pattern for the simple non-nuxt setup to allow organizing tests into subdirectories. 

Reproduction:
https://stackblitz.com/edit/nuxt-test-utils-issues-1800?file=package.json&startScript=test

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
