### PR TITLE
fix: allow vitest 5 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "happy-dom": ">=20.0.11",
     "jsdom": ">=27.4.0",
     "playwright-core": "^1.43.1",
-    "vitest": "^4.0.2"
+    "vitest": "^4.0.2 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "@cucumber/cucumber": {


### PR DESCRIPTION
v4.3.0 ships vitest 5 support (#1802) but the optional peer still declares `^4.0.2`, so npm users get ERESOLVE when installing vitest 5 next to `@nuxt/test-utils`. This widens the range to `^4.0.2 || ^5.0.0`.

The vitest devDependency and lockfile are untouched, lint and `test:types` pass locally.

resolves #1803