### PR TITLE
fix(config): exclude aliased mock packages from optimizeDeps in browser mode

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -453,6 +453,10 @@ async function resolveConfig<T extends ViteUserConfig & { test?: VitestConfig } 
       resolvedConfig.optimizeDeps ??= {}
       resolvedConfig.optimizeDeps.include ??= []
       resolvedConfig.optimizeDeps.include.push('@testing-library/vue', 'h3-next/generic')
+
+      // aliased to mocks, excluded from pre-bundling to avoid runtime discovery
+      resolvedConfig.optimizeDeps.exclude ??= []
+      resolvedConfig.optimizeDeps.exclude.push('@vue/devtools-kit', '@vue/devtools-core')
     }
 
     resolvedConfig.plugins!.push({


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

When packages using dependencies aliased to mocks are added to `optimizeDeps.include` (following `nuxt dev` optimize hint), it triggers runtime re-bundling and causes errors in vitest5 browser mode. (this occurs when vite cache is not present, such as in ci).

### Reproduction

before: https://stackblitz.com/edit/nuxt-test-utils-pr-1816-before?file=package.json
after: https://stackblitz.com/edit/nuxt-test-utils-pr-1816-after?file=package.json

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
