### PR TITLE
fix(e2e): restore console after use nuxt kit

### DIFF
--- a/examples/app-vitest/test/e2e/server-logs.spec.ts
+++ b/examples/app-vitest/test/e2e/server-logs.spec.ts
@@ -3,7 +3,7 @@ import { $fetch, clearServerLogs, getServerLogs, setup } from '@nuxt/test-utils/
 import { describe, expect, it, vi } from 'vitest'
 
 await setup({
-  rootDir: fileURLToPath(new URL('../', import.meta.url)),
+  rootDir: fileURLToPath(new URL('../../', import.meta.url)),
 })
 
 describe('server log capture', () => {

--- a/src/e2e/nuxt.ts
+++ b/src/e2e/nuxt.ts
@@ -56,12 +56,14 @@ export async function loadFixture() {
 
   // TODO: share Nuxt instance with running Nuxt if possible
   if (ctx.options.build) {
-    const { loadNuxt } = await loadKit(ctx.options.rootDir)
+    const { loadNuxt, logger } = await loadKit(ctx.options.rootDir)
     ctx.nuxt = await loadNuxt({
       cwd: ctx.options.rootDir,
       dev: ctx.options.dev,
       overrides: ctx.options.nuxtConfig,
       configFile: ctx.options.configFile,
+    }).finally(() => {
+      logger.restoreAll()
     })
 
     const buildDir = ctx.nuxt.options.buildDir
@@ -81,6 +83,8 @@ export async function buildFixture() {
   // Hide build info for test
   const prevLevel = logger.level
   logger.level = ctx.options.logLevel
-  await buildNuxt(ctx.nuxt!)
-  logger.level = prevLevel
+  await buildNuxt(ctx.nuxt!).finally(() => {
+    logger.level = prevLevel
+    logger.restoreAll()
+  })
 }

--- a/test/fixtures/output-console/nuxt.config.ts
+++ b/test/fixtures/output-console/nuxt.config.ts
@@ -1,0 +1,1 @@
+export default defineNuxtConfig({})

--- a/test/fixtures/output-console/test/test1.spec.ts
+++ b/test/fixtures/output-console/test/test1.spec.ts
@@ -1,0 +1,24 @@
+import { fileURLToPath } from 'node:url'
+import { setup } from '@nuxt/test-utils/e2e'
+import { beforeAll, beforeEach, describe, it } from 'vitest'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../', import.meta.url)),
+})
+
+describe('console', async () => {
+  beforeAll(() => {
+    console.log('=== beforeAll info ===')
+    console.error('=== beforeAll error ===')
+  })
+
+  beforeEach(() => {
+    console.log('=== beforeEach info ===')
+    console.error('=== beforeEach error ===')
+  })
+
+  it('test1', () => {
+    console.log('=== test1 info ===')
+    console.error('=== test1 error ===')
+  })
+})

--- a/test/fixtures/output-console/tsconfig.json
+++ b/test/fixtures/output-console/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../.nuxt/tsconfig.json"
+}

--- a/test/unit/output-console.spec.ts
+++ b/test/unit/output-console.spec.ts
@@ -1,0 +1,37 @@
+import { x } from 'tinyexec'
+import { join } from 'node:path'
+import { rm } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { afterAll, describe, expect, it } from 'vitest'
+
+const TEST_TIMEOUT = process.env.CI ? 60_000 : 30_000
+
+const fixtureDir = fileURLToPath(new URL('../fixtures/output-console', import.meta.url))
+
+describe('output console', () => {
+  afterAll(async () => {
+    await rm(join(fixtureDir, '.nuxt'), { recursive: true, force: true })
+  })
+
+  it('should output console messages to vitest', async () => {
+    const result = await x('vitest', ['run'], {
+      nodeOptions: {
+        cwd: fixtureDir,
+      },
+    })
+
+    expect.assert(result.exitCode === 0, result.stderr)
+
+    expect(result.stdout).toContain('=== beforeAll info ===')
+    expect(result.stderr).toContain('=== beforeAll error ===')
+
+    expect(result.stdout).toContain('=== beforeEach info ===')
+    expect(result.stderr).toContain('=== beforeEach error ===')
+
+    expect(result.stdout).toContain('=== test1 info ===')
+    expect(result.stderr).toContain('=== test1 error ===')
+
+    expect(result.stdout).toContain('=== test1 info ===')
+    expect(result.stderr).toContain('=== test1 error ===')
+  }, TEST_TIMEOUT)
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves #350
resolves #795

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

add `logger.restoreAll()` after `buildNuxt` and `loadNuxt` to restore console output captured by consola.

#### Reproductin

- issue-350 https://stackblitz.com/edit/nuxt-test-utils-issues-350 
- issue-795 https://stackblitz.com/edit/nuxt-test-utils-issues-795

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
